### PR TITLE
Reduce content on the homepage

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -11,7 +11,7 @@ View the course materials:
 * [Teach First](/teach-first)
 * [UCL](/ucl)
 
-Each set of materials cover five core areas:
+Each set of materials covers five core areas:
 
 * behaviour management
 * pedagogy

--- a/content/index.md
+++ b/content/index.md
@@ -2,24 +2,16 @@
 title: Support for early career teachers
 ---
 
-The early career framework (ECF) is designed to make sure early career teachers (ECTs) focus on learning the things that make the most difference in the classroom and their professional practice.
+The Department for Education has selected 4 expert teacher training providers who have each developed their own accredited materials based on the early career framework.
 
-The DfE-accredited materials, underpinned by the ECF, will support early career teachers. They’ll develop the essential knowledge and skills to set them up for a successful and fulfilling career in teaching.
-
-ECTs will receive regular mentoring. Mentors also have access to a separate set of support materials, in addition to being able to view the ECT training programme.
-
-## What material is available?
-
-The materials published here are from the perspective of a mentor. Use them in whichever way that best suits you.
-
-The Department for Education has selected 4 expert teacher training providers who have each developed their own accredited materials based on the ECF. Read more about the support available to ECTs and mentors from these suppliers on their own websites, or in the course materials below:
+View the course materials:
 
 * [Ambition Institute](/ambition-institute/)
 * [Education Development Trust](/education-development-trust)
 * [Teach First](/teach-first)
 * [UCL](/ucl)
 
-Each set of materials cover the five core areas of the ECF:
+Each set of materials cover five core areas:
 
 * behaviour management
 * pedagogy
@@ -27,6 +19,4 @@ Each set of materials cover the five core areas of the ECF:
 * assessment
 * professional behaviours
 
-Each programme is structured differently, but they all contain approximately the same number of hours of self-study material.
-
-Use this service to access training and support materials for the Early Career Framework (ECF), accredited by the Department for Education.
+Each set is structured differently, but they all contain approximately the same number of hours of self-study material.


### PR DESCRIPTION
Some of the content is filler or out of date (future tense).

This cuts the content down to the basics, as most users will just want to access the materials.