### PR TITLE
Add Crown Copyright to footer

### DIFF
--- a/layouts/partials/footer.slim
+++ b/layouts/partials/footer.slim
@@ -24,6 +24,9 @@ footer.govuk-footer role='contentinfo'
           ] Open Government Licence v3.0
           | , except where otherwise stated 
 
+      .govuk-footer__meta-item
+        a.govuk-footer__link.govuk-footer__copyright-logo[href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"]
+          | © Crown copyright
 / script src="/javascript/govuk-frontend.js"
 / script
 /   | window.GOVUKFrontend.initAll() ;


### PR DESCRIPTION
This matches the existing service and is part of the GOV.UK brand.

Depends on #10