### PR TITLE
Tidy up some ordered lists

### DIFF
--- a/content/ambition-institute/year-1-behaviour/autumn-week-1-mentor-materials.md
+++ b/content/ambition-institute/year-1-behaviour/autumn-week-1-mentor-materials.md
@@ -11,19 +11,14 @@ caption: "Autumn week 1"
 Meet with your teacher and use the following prompts as the basis for a coaching contracting discussion. Contracting is most effective when both parties (yourself and the ECT) answer questions for each other.
 
 1. Professional prompts
-
    - What is important to you in your work?
    - What do you want to get out of this process?
    - What do you need from me to make this work well?
-
 2. Procedural prompts
-
    - What is the best way for us to communicate and when?
    - When are the best times to meet for our mentor sessions?
    - What classes/subjects are best to observe?
-
 3. Psychological prompts
-
    - What does an effective professional relationship look like for you? Can you give me an example?
    - What experience have you had of observation? How can we make observation an effective experience?
    - What experiences do you have of coaching? What might we need to do to embrace this coaching approach?

--- a/content/ambition-institute/year-1-behaviour/autumn-week-3-ect-reflect.md
+++ b/content/ambition-institute/year-1-behaviour/autumn-week-3-ect-reflect.md
@@ -16,7 +16,5 @@ Ms Silva can improve pupil behaviour and learning by understanding that:
 ### Reflect on the following questions
 
 1. What did you see in this module that you already do or have seen in other classrooms?
-
 2. What do you feel is the gap between your current practice and what you have seen in this module?
-
 3. Which of the ‘key takeaways’ do you need to focus on? Where and when might you try to apply them to your teaching?

--- a/content/ambition-institute/year-1-behaviour/autumn-week-4-ect-reflect.md
+++ b/content/ambition-institute/year-1-behaviour/autumn-week-4-ect-reflect.md
@@ -15,9 +15,6 @@ Ms Silva can direct pupil attention and increase learning by understanding that:
 
 ### Reflect on the following questions
 
-1. What did you see in this module that you already do or have seen in other
-   classrooms?
-
+1. What did you see in this module that you already do or have seen in other classrooms?
 2. What do you feel is the gap between your current practice and what you have seen in this module?
-
 3. Which of the ‘key takeaways’ do you need to focus on? Where and when might you try to apply them to your teaching?

--- a/content/ambition-institute/year-1-instruction/spring-week-1-mentor-materials.md
+++ b/content/ambition-institute/year-1-instruction/spring-week-1-mentor-materials.md
@@ -11,22 +11,19 @@ caption: "Spring week 1"
 Meet with your teacher and use the following prompts as the basis for a coaching contracting discussion. Contracting is most effective when both parties (yourself and the ECT) answer questions for each other.
 
 1. Professional prompts
-
-- What is important to you in your work?
-- What do you want to get out of this process?
-- What do you need from me to make this work well?
+  - What is important to you in your work?
+  - What do you want to get out of this process?
+  - What do you need from me to make this work well?
 
 2. Procedural prompts
-
-- What is the best way for us to communicate and when?
-- When are the best times to meet for our mentor sessions?
-- What classes/subjects are best to observe?
+  - What is the best way for us to communicate and when?
+  - When are the best times to meet for our mentor sessions?
+  - What classes/subjects are best to observe?
 
 3. Psychological prompts
-
-- What does an effective professional relationship look like for you? Can you give me an example?
-- What experience have you had of observation? How can we make observation an effective experience?
-- What experiences do you have of coaching? What might we need to do to embrace this coaching approach?
+  - What does an effective professional relationship look like for you? Can you give me an example?
+  - What experience have you had of observation? How can we make observation an effective experience?
+  - What experiences do you have of coaching? What might we need to do to embrace this coaching approach?
 
 ### Context-specific meeting
 

--- a/content/ambition-institute/year-1-subject/summer-week-1-mentor-materials.md
+++ b/content/ambition-institute/year-1-subject/summer-week-1-mentor-materials.md
@@ -11,22 +11,17 @@ caption: "Summer week 1"
 Meet with your teacher and use the following prompts as the basis for a coaching contracting discussion. Contracting is most effective when both parties (yourself and the ECT) answer questions for each other.
 
 1. Professional prompts
-
-- What is important to you in your work?
-- What do you want to get out of this process?
-- What do you need from me to make this work well?
-
+  - What is important to you in your work?
+  - What do you want to get out of this process?
+  - What do you need from me to make this work well?
 2. Procedural prompts
-
-- What is the best way for us to communicate and when?
-- When are the best times to meet for our mentor sessions?
-- What classes/subjects are best to observe?
-
+  - What is the best way for us to communicate and when?
+  - When are the best times to meet for our mentor sessions?
+  - What classes/subjects are best to observe?
 3. Psychological prompts
-
-- What does an effective professional relationship look like for you? Can you give me an example?
-- What experience have you had of observation? How can we make observation an effective experience?
-- What experiences do you have of coaching? What might we need to do to embrace this coaching approach?
+  - What does an effective professional relationship look like for you? Can you give me an example?
+  - What experience have you had of observation? How can we make observation an effective experience?
+  - What experiences do you have of coaching? What might we need to do to embrace this coaching approach?
 
 ### Context-specific meeting
 

--- a/content/education-development-trust/year-1-a-people-profession/summer-week-1-ect-evidence.md
+++ b/content/education-development-trust/year-1-a-people-profession/summer-week-1-ect-evidence.md
@@ -126,28 +126,23 @@ Watch the following video and consider the way in which the two teachers approac
 Video transcript.
 
 1. How do you prepare for parents' evening?
-   <p class="p1">
-     <b>Year 6:</b> I make a pile for each student which includes a sample of
-     their work to show parents. I have a template where I jot down some notes
-     for each pupil in advance of the meetings – what’s going well, areas for
-     improvement and some next steps for their child and how the parents can
-     help. I do this so I don’t forget anything and I feel confident that I’m
-     making the most of the time when I have parents and carers in front of me.
-   </p>
-   <p class="p1">
-     <b>Secondary:</b> It depends on the year group to be honest. If it is a KS3
-     year group, I sometimes teach over 100 pupils in the year so I always print
-     out a page with pupil names and pictures so I can refer to it if I need to.
-     I would hate to make a mistake and so it is a discreet way to make sure I
-     give the right information to the right parents. I always prepare a data
-     sheet which has their latest test scores, homework and attendance records
-     on it – and for GCSE classes I will include targets. I usually bring the
-     class set of books with me as well, it’s helpful to be able to show
-     examples of work to parents so they understand what I am talking about.
-   </p>
+  * **Year 6:** I make a pile for each student which includes a sample of
+  their work to show parents. I have a template where I jot down some notes
+  for each pupil in advance of the meetings – what’s going well, areas for
+  improvement and some next steps for their child and how the parents can
+  help. I do this so I don’t forget anything and I feel confident that I’m
+  making the most of the time when I have parents and carers in front of me.
+  * **Secondary:** It depends on the year group to be honest. If it is a KS3
+   year group, I sometimes teach over 100 pupils in the year so I always print
+   out a page with pupil names and pictures so I can refer to it if I need to.
+   I would hate to make a mistake and so it is a discreet way to make sure I
+   give the right information to the right parents. I always prepare a data
+   sheet which has their latest test scores, homework and attendance records
+   on it – and for GCSE classes I will include targets. I usually bring the
+   class set of books with me as well, it’s helpful to be able to show
+   examples of work to parents so they understand what I am talking about.
 2. How do you manage the conversation to make best use of their time?
-   <p class="p1">
-     <b>Year 6:</b> I start by explaining what I am going to cover in the
+   * **Year 6:** I start by explaining what I am going to cover in the
      conversation and if that sounds good to them or is there is something they
      particularly want to talk about which I haven’t mentioned. This helps
      because sometimes parents have a really specific question which they ask
@@ -155,9 +150,7 @@ Video transcript.
      is frustrating for the parent as they came with that question in mind and
      then leave without having it answered. I try to not speak for the full slot
      to make sure that their questions have time to be answered.
-   </p>
-   <p class="p1">
-     <b>Secondary: </b>I always start by saying that the slot is just 10 minutes
+   * **Secondary:** I always start by saying that the slot is just 10 minutes
      and that we will have to stick to time to be fair to the other parents. If
      at the end of the slot there feels like there is still a lot to talk about,
      I will suggest that I follow up the next day to arrange a longer meeting or
@@ -166,10 +159,8 @@ Video transcript.
      would have already spoken to them and so when we meet at parents evening I
      am picking up the thread of a conversation and updating rather than
      informing for the first time.
-   </p>
 3. What are your top tips for parents' evening and dealing with difficult conversations?
-   <p class="p1">
-     <b>Year 6:</b> My top tip is to prepare as much as possible. Better to be
+   * **Year 6:** My top tip is to prepare as much as possible. Better to be
      over prepared than under. These are their children and so it shows respect
      to the parents that you have taken the time to plan. Always start by saying
      something positive about the pupil – not a generic comment like they are
@@ -178,9 +169,7 @@ Video transcript.
      son/daughter is – just the other day we had to wait for the PE bus to
      arrive and they didn’t get frustrated but calmly took their book out to
      read!”
-   </p>
-   <p class="p2">
-     <b>Secondary: </b>My top tip is to remain polite and professional
+   * **Secondary:** My top tip is to remain polite and professional
      throughout. Start by smiling and shake their hand, if this is culturally
      appropriate. Say that you are pleased to finally meet them and share
      something positive which you have noticed about their child. If you are
@@ -188,8 +177,7 @@ Video transcript.
      sit in with you and suggest that you meet in a side classroom for some
      privacy. Always follow up the next day if there was a question or query
      which you couldn’t answer.
-   </p>
-    {/details}
+{/details}
 
 ### In your notepad
 
@@ -221,54 +209,47 @@ What steps does the teacher take to build a relationship with the parents/carers
 {details}
 Video transcript.
 
-<p class="p1">
-  When I start with my new class I know that building a relationship with the
-  parents and carers is really important.
-</p>
-<p class="p1">
-  Being a primary school, lots of our parents still drop their kids off or
-  collect them at the end of the day so I make a point of standing outside to
-  say hello and make the initial connection. I keep a list of pupils in my
-  pocket so I tick off when I have met each parent or carer, and any that I
-  haven’t met within the first few weeks I will give a quick call to say hello
-  and introduce myself. I think it is important that families feel they can
-  speak to me if they need to – some of our parents are difficult to engage and
-  so a friendly first impression helps a lot.
-</p>
-<p class="p1">
-  We have a policy of emailing home schemes of work and information about what
-  we will be learning each half term. I find this is a really great way to
-  communicate with families and I always include suggestions of activities which
-  they can do with their children – simple stuff in the home or local area but
-  also ideas of websites or books which would support the theme or topic we are
-  doing.
-</p>
-<p class="p1">
-  Our school parent afternoons tend to be quite early in the year – this is so
-  we have a chance to sit down formally with each family and speak properly with
-  them about their child. Almost every parent or carer I have ever met is
-  delighted to talk about their child and how they can help them with their
-  learning. I like to host these in my classroom so they can see where their
-  child is all day, examples of their work on display and it is a quiet space so
-  they can raise any worries or concerns. I always follow up with a quick email
-  to say thank you and it was nice to meet you. It’s a simple thing but it shows
-  that I am open to continuing the dialogue and we are working together to
-  support their child.
-</p>
-<p class="p1">
-  I do sometimes use text messages – parents sign up to this at the start of the
-  year to say they are happy to receive information this way. I tend to use
-  texts for reminders or quick praise messages as they are short and easy to
-  send. Parents seem to like it.
-</p>
-<p class="p1">
-  One other thing I do to get to know parents and carers is ask the pupils. I do
-  a ‘getting to know you’ activity when I first meet my class - they tell the
-  class about who they live with and maybe some things like how they travel to
-  school or who picks them up after school. This is always fun and I like being
-  able to ask parents about their e-scooters or how their elderly relative who
-  lives with them is doing.
-</p>
+When I start with my new class I know that building a relationship with the
+parents and carers is really important.
+
+Being a primary school, lots of our parents still drop their kids off or
+collect them at the end of the day so I make a point of standing outside to
+say hello and make the initial connection. I keep a list of pupils in my
+pocket so I tick off when I have met each parent or carer, and any that I
+haven’t met within the first few weeks I will give a quick call to say hello
+and introduce myself. I think it is important that families feel they can
+speak to me if they need to – some of our parents are difficult to engage and
+so a friendly first impression helps a lot.
+
+We have a policy of emailing home schemes of work and information about what
+we will be learning each half term. I find this is a really great way to
+communicate with families and I always include suggestions of activities which
+they can do with their children – simple stuff in the home or local area but
+also ideas of websites or books which would support the theme or topic we are
+doing.
+
+Our school parent afternoons tend to be quite early in the year – this is so
+we have a chance to sit down formally with each family and speak properly with
+them about their child. Almost every parent or carer I have ever met is
+delighted to talk about their child and how they can help them with their
+learning. I like to host these in my classroom so they can see where their
+child is all day, examples of their work on display and it is a quiet space so
+they can raise any worries or concerns. I always follow up with a quick email
+to say thank you and it was nice to meet you. It’s a simple thing but it shows
+that I am open to continuing the dialogue and we are working together to
+support their child.
+
+I do sometimes use text messages – parents sign up to this at the start of the
+year to say they are happy to receive information this way. I tend to use
+texts for reminders or quick praise messages as they are short and easy to
+send. Parents seem to like it.
+
+One other thing I do to get to know parents and carers is ask the pupils. I do
+a ‘getting to know you’ activity when I first meet my class - they tell the
+class about who they live with and maybe some things like how they travel to
+school or who picks them up after school. This is always fun and I like being
+able to ask parents about their e-scooters or how their elderly relative who
+lives with them is doing.
  {/details}
 
 ### In your notepad

--- a/content/education-development-trust/year-1-assessment-feedback-and-questioning/summer-week-1-ect-evidence.md
+++ b/content/education-development-trust/year-1-assessment-feedback-and-questioning/summer-week-1-ect-evidence.md
@@ -161,10 +161,15 @@ allows me to have a few words as they go out, and is a nice way to end the sessi
 I then read through their answers, sometimes there and then for a snapshot of progress,
 or later when I’m planning the next lesson I can sort the tickets into three piles:
 
-1. Pupils who have understood, 2. Pupils who have sort of understood, 3. Pupils who
-   have not understood. This gives me the big picture quickly and easily. It helps me
-   know my starting point for the next set of lessons, and what misconceptions are likely
-   to persist. {/details}
+1. Pupils who have understood
+2. Pupils who have sort of understood
+3. Pupils who have not understood
+
+This gives me the big picture quickly and easily. It helps me know my starting
+point for the next set of lessons, and what misconceptions are likely to
+persist.
+
+{/details}
 
 ### In your notepad
 

--- a/content/education-development-trust/year-1-assessment-feedback-and-questioning/summer-week-6-ect-classroom-practice.md
+++ b/content/education-development-trust/year-1-assessment-feedback-and-questioning/summer-week-6-ect-classroom-practice.md
@@ -188,22 +188,17 @@ For a lesson you have coming up, develop a multiple-choice quiz that you could u
 For example, the teacher has taught one lesson in a sequence of lessons on the Battle of Hastings. He uses the following multiple-choice questions to test pupils' knowledge as they go into lesson 2.
 
 1. Why might Harold’s army have been tired before the Battle of Hastings?
-
-   - They had recently fought Harald Hadrada.
-   - They had recently fought King Cnut.
-   - They had recently fought William Duke of Normandy.
-
+ - They had recently fought Harald Hadrada.
+ - They had recently fought King Cnut.
+ - They had recently fought William Duke of Normandy.
 2. What other reason did Harold’s army have for being tired?
-
-   - They had marched to and from London Bridge.
-   - They had marched to and from Stamford Bridge.
-   - They had marched to and from Severn Bridge.
-
+  - They had marched to and from London Bridge.
+  - They had marched to and from Stamford Bridge.
+  - They had marched to and from Severn Bridge.
 3. What advantages did William’s army have ahead of the battle?
-
-   - They were a large army of mostly amateur soldiers.
-   - They arrived early and positioned themselves atop Senlac Hill.
-   - They were well equipped with horses and weapons.
+ - They were a large army of mostly amateur soldiers.
+ - They arrived early and positioned themselves atop Senlac Hill.
+ - They were well equipped with horses and weapons.
 
 #### 5 quick questions/If this is the answer, what’s the question?
 

--- a/content/education-development-trust/year-1-developing-effective-classroom-practice/spring-week-5-ect-classroom-practice.md
+++ b/content/education-development-trust/year-1-developing-effective-classroom-practice/spring-week-5-ect-classroom-practice.md
@@ -267,19 +267,16 @@ Ideas for challenging might include:
 #### Make effective use of resources, including additional adults
 
 1. For a lesson or sequence of lessons you are going to teach, review the resources you plan to use. Use the following questions to guide your thinking:
-
-- Who might need additional resources?
-- What kind of additional resources might be needed?
-- Have I got enough written structures in place for this lesson, e.g. sentence stems?
-- Have I used word banks or glossaries to support vocabulary?
-- Are there any concrete resources, such as props or models that might help aid understanding?
-
+  - Who might need additional resources?
+  - What kind of additional resources might be needed?
+  - Have I got enough written structures in place for this lesson, e.g. sentence stems?
+  - Have I used word banks or glossaries to support vocabulary?
+  - Are there any concrete resources, such as props or models that might help aid understanding?
 2. Plan how you will deploy any additional adults you have in the classroom:
-
-- Who will they work with?
-- What information might they need prior to the lesson?
-- What misconceptions might they hold which you do not want to pass onto pupils?
-- When should they withdraw their support and how?
+  - Who will they work with?
+  - What information might they need prior to the lesson?
+  - What misconceptions might they hold which you do not want to pass onto pupils?
+  - When should they withdraw their support and how?
 
 You do not need to create distinct tasks for different pupils. Think about how you can provide support to pupils so that they can all achieve and reach a high standard.
 

--- a/content/education-development-trust/year-1-developing-effective-classroom-practice/spring-week-6-mentor-materials.md
+++ b/content/education-development-trust/year-1-developing-effective-classroom-practice/spring-week-6-mentor-materials.md
@@ -88,7 +88,6 @@ Use the final activity in the self-directed study materials to look through all 
 2. What do you need to learn more about?
 3. Have you achieved your goal?
    Ask the ECT to share their responses. Support the ECT to come with an action plan for how they can address the areas they identify in Question 2. Some prompts to support:
-
-- Which colleagues could the ECT go to in order to learn about X?
-- What might be the focus of further reading?
-- What might the ECT need to work on in terms of their classroom practice moving forward? How could they be supported to do this?
+  - Which colleagues could the ECT go to in order to learn about X?
+  - What might be the focus of further reading?
+  - What might the ECT need to work on in terms of their classroom practice moving forward? How could they be supported to do this?

--- a/content/education-development-trust/year-1-the-importance-of-subject-and-curriculum-knowledge/spring-week-2-mentor-materials.md
+++ b/content/education-development-trust/year-1-the-importance-of-subject-and-curriculum-knowledge/spring-week-2-mentor-materials.md
@@ -146,15 +146,15 @@ Answers:
 2. When the capacity of working memory is exceeded.
 3. Because if cognitive overload occurs, we are unlikely to be able to transfer new information into our long-term memory… we learn very little.
 4. Possible options:
-   - Tailor lessons to pupils’ existing knowledge and skills
-   - Use worked examples
-   - Gradually increase independence
-   - Cut out inessential information from explanations
-   - Don’t overload slides with too much information
-   - Present essential information together
+  - Tailor lessons to pupils’ existing knowledge and skills
+  - Use worked examples
+  - Gradually increase independence
+  - Cut out inessential information from explanations
+  - Don’t overload slides with too much information
+  - Present essential information together
 5. Possible answers:
-   - We only have so much time to teach pupils so need to focus on what’s essential.
-   - It helps to boil the subject down to its ‘essence’ so that pupils understand the core principles that make that subject what it is.
+  - We only have so much time to teach pupils so need to focus on what’s essential.
+  - It helps to boil the subject down to its ‘essence’ so that pupils understand the core principles that make that subject what it is.
 
 ### Linking learning to what pupils already know (20 minutes)
 

--- a/content/education-development-trust/year-2-deepening-assessment-feedback-and-questioning/summer-week-1-mentor-materials.md
+++ b/content/education-development-trust/year-2-deepening-assessment-feedback-and-questioning/summer-week-1-mentor-materials.md
@@ -98,18 +98,16 @@ Pose the following question: How can you scaffold self-assessment by sharing mod
 Model work helps pupils gain an understanding about what quality learning ‘looks like’ and – by highlighting the key details and characteristics – what they need to do to achieve the standard. It is underpinned by the idea that it is easier to understand how to do something by being _shown_ how to do it rather than being given a description of how to do it. What could this look like?
 
 1. Prepared model work:
-
-   - Pupils see a complete example, so they know what they are aiming for.
-   - Teacher can share multiple prepared responses showing a variety of high-quality responses
-   - Can be used to identify errors and how to address them
-   - Pupils see the product or outcome they are aiming for
-   - Pupils and teacher can analyse, dissect and evaluate the features within a model.
+  - Pupils see a complete example, so they know what they are aiming for.
+  - Teacher can share multiple prepared responses showing a variety of high-quality responses
+  - Can be used to identify errors and how to address them
+  - Pupils see the product or outcome they are aiming for
+  - Pupils and teacher can analyse, dissect and evaluate the features within a model.
 
 2. Worked examples:
-
-   - Improve learning by reducing cognitive load during skill acquisition
-   - Model the process or procedure and thinking required to solve a particular problem, as well as showing the product
-   - Can be used more than once and completed in collaboration with pupils with pupils partly or fully leading the worked example depending on the level of scaffold required.
+  - Improve learning by reducing cognitive load during skill acquisition
+  - Model the process or procedure and thinking required to solve a particular problem, as well as showing the product
+  - Can be used more than once and completed in collaboration with pupils with pupils partly or fully leading the worked example depending on the level of scaffold required.
 
 Watch the video from this week's ECT self-study materials.
 

--- a/content/education-development-trust/year-2-deepening-assessment-feedback-and-questioning/summer-week-3-mentor-materials.md
+++ b/content/education-development-trust/year-2-deepening-assessment-feedback-and-questioning/summer-week-3-mentor-materials.md
@@ -76,17 +76,14 @@ Suggested dialogue for mentors:
 In the next part of the topic, you will work with a colleague to identify efficient approaches to marking and alternative approaches to providing feedback. We’ve got ten minutes to prepare.
 
 1. What efficient approaches to marking can you think of that you might want to steer your colleague to discuss?
-
-   - Marking codes
-   - Live marking
-   - Self-Assessment
-   - Peer-Assessment
-
+  - Marking codes
+  - Live marking
+  - Self-Assessment
+  - Peer-Assessment
 2. What alternative approaches to providing feedback might you want to steer your colleague to discuss?
-
-   - Peer feedback
-   - Whole class feedback
-   - Verbal feedback
+  - Peer feedback
+  - Whole class feedback
+  - Verbal feedback
 
 What specific questions might you want to ask?
 

--- a/content/education-development-trust/year-2-enhancing-classroom-practice-grouping-and-tailoring/spring-week-2-ect-evidence.md
+++ b/content/education-development-trust/year-2-enhancing-classroom-practice-grouping-and-tailoring/spring-week-2-ect-evidence.md
@@ -223,7 +223,8 @@ Video script.
 2. Decision-making sheet (Crisis manager)
 3. A4 map of the island for part 2 of the task
 4. Notepaper for the information coordinator
-   {/details}
+
+{/details}
 
 ## Flexibly grouping pupils within a class to provide more tailored support can be effective, but care should be taken to monitor its impact on engagement and motivation, particularly for low-attaining pupils
 

--- a/content/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-2-ect-theory.md
+++ b/content/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-2-ect-theory.md
@@ -347,19 +347,14 @@ There’s a well-known phenomenon called the curse of expertise, which simply pu
 Time is one of the most important resources you have as a teacher and so it’s important you do what you can to conserve it. Routines can help with this by enabling pupils to complete a task in the quickest, simplest way that requires you to give only a few brief instructions. The following suggestions will support you when planning and teaching your routines.
 
 1. Be clear on what you want pupils to do
-   When creating any routine, it is important that you are clear on what you want pupils to do. It is therefore useful if you plan your instructions in advance and ensure that they are:
-
-   - Specific and observable – they make the behaviours pupils are expected to exhibit explicit. This also makes it easy to observe whether pupils are doing them or not. For example, saying, “Pencils down and eyes to me” is specific and observable whereas saying, “Pay attention” is vague and abstract.
-   - Sequential – they are given in the order that you want pupils to follow them. For example, “Put your pens down, close your books, and eyes on me”.
-   - Manageable – use fewer words to make the instruction easier for pupils to process and remember. You can replace words with numbers or gestures to make them even quicker to deliver.
-
+  When creating any routine, it is important that you are clear on what you want pupils to do. It is therefore useful if you plan your instructions in advance and ensure that they are:
+  - Specific and observable – they make the behaviours pupils are expected to exhibit explicit. This also makes it easy to observe whether pupils are doing them or not. For example, saying, “Pencils down and eyes to me” is specific and observable whereas saying, “Pay attention” is vague and abstract.
+  - Sequential – they are given in the order that you want pupils to follow them. For example, “Put your pens down, close your books, and eyes on me”.
+  - Manageable – use fewer words to make the instruction easier for pupils to process and remember. You can replace words with numbers or gestures to make them even quicker to deliver.
 2. Teach and model your routine in small steps
-
-   - Teaching a routine in small steps helps to make it manageable and memorable for pupils. When teaching each step, make your behavioural expectations explicit by modelling the step as you describe it. This helps to build pupils’ mental model of the routine and makes it more likely they will achieve success.
-
+  - Teaching a routine in small steps helps to make it manageable and memorable for pupils. When teaching each step, make your behavioural expectations explicit by modelling the step as you describe it. This helps to build pupils’ mental model of the routine and makes it more likely they will achieve success.
 3. Practise your routine at the beginning of the school year until pupils meet your expectations
-
-   - Practice is an integral part of effective teaching; ensuring pupils have opportunities to practise, with appropriate guidance and feedback, increases the chances of them being successful when completing the routine. Frame guidance and feedback positively to motivate pupils to do better next time.
+  - Practice is an integral part of effective teaching; ensuring pupils have opportunities to practise, with appropriate guidance and feedback, increases the chances of them being successful when completing the routine. Frame guidance and feedback positively to motivate pupils to do better next time.
 
 Note that while pupils may master routines after lots of practise at the start of the year, over time you may notice some routines slipping a little. Demonstrate the high expectations you have of your pupils by positively reinforcing your routines and practising them again if necessary. This is the key to maintaining high quality, efficient routines.
 

--- a/content/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-5-ect-related-early-career-framework-strands.md
+++ b/content/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-5-ect-related-early-career-framework-strands.md
@@ -4,7 +4,7 @@ previous_title: "Theory"
 previous_path: "/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-5-ect-theory"
 ---
 
-### High Expectations
+## High Expectations
 
 1.4 Setting clear expectations can help communicate shared values that improve classroom and school culture.
 
@@ -16,7 +16,7 @@ _1f. Teaching and rigorously maintaining clear behavioural expectations (e.g. fo
 
 _1g. Applying rules, sanctions and rewards in line with school policy, escalating behaviour incidents as appropriate._
 
-### Managing Behaviour
+## Managing Behaviour
 
 7.2 A predictable and secure environment benefits all pupils, but is particularly valuable for pupils with special educational needs.
 

--- a/content/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-7-ect-theory.md
+++ b/content/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-7-ect-theory.md
@@ -156,11 +156,11 @@ Record your reflection in your notepad:
 
 Another way to support pupils to stay focused and engaged during lessons is to make the start and end of activities clear. This can help to keep the pace of the lesson and therefore keep pupils alert and focused. Some ways you can do this are:
 
-1. Clear start
+1. **Clear start.**
    Make sure that all pupils know when to start the task by using a clear cue. Everyone starting tasks at the same time means that it keeps pupils focused and the environment purposeful as pupils don’t drift into starting activities or have a quick chat before they begin. For example, when starting pupils off on a task, you might say, “Three, two one, off you go.”
-2. Clear finish
+2. **Clear finish.**
    Ensuring that all pupils know when the activity has ended and what they should do next means that pupils are not finishing at different times and have a chance to start to be off task. Making it clear when the time is up and what to do to show that they are ready is key to you being able to get the pupils' attention and move on with the lesson. For example, using a timer with a sound to indicate time is up and then giving instructions of what to do such as, “Pencils down, eyes on me.”
-3. Provide positive reinforcement
+3. **Provide positive reinforcement.**
    Positively reinforcing your expectations helps to ensure all pupils start and finish the task as and when you directed. For example, when starting a task, you might say, “I can see four tables have started, well done.” Equally, when finishing a task, you might say, “Pencils down, eyes on me, thanks front row, I have all of you looking at me.”
 
 #### Making the beginning and end of activities clear in action

--- a/content/teach-first/year-1-how-can-you-use-assessment-and-feedback-to-greatest-effect/spring-week-5-ect-theory.md
+++ b/content/teach-first/year-1-how-can-you-use-assessment-and-feedback-to-greatest-effect/spring-week-5-ect-theory.md
@@ -44,13 +44,14 @@ There are four things that help most teachers use self-assessment effectively:
 2. Secondly, share specific and understandable success criteria that help your students know how they're doing along the way.
 3. Plan opportunities for your students to use those success criteria independently to identify both their own successes and the things that they need to improve, and finally,
 4. Plan opportunities for your students to work independently to make the identified improvements and I can't stress that last point enough. The most important thing about feedback is what a student does with it.
-   Effective peer assessment involves students thinking about someone else's piece of
-   work and how it could be improved. Peer assessment can be a powerful learning tool
-   and it's not actually about students marking each other's work, as sometimes it's
-   thought, and, structured well, it can have a positive impact both for the student
-   receiving the peer assessment feedback as well as for the student giving it. Often
-   those students who engage in effective peer assessment tasks become much more aware
-   of how to improve their own work by virtue of trying to improve others'.
+
+Effective peer assessment involves students thinking about someone else's piece of
+work and how it could be improved. Peer assessment can be a powerful learning tool
+and it's not actually about students marking each other's work, as sometimes it's
+thought, and, structured well, it can have a positive impact both for the student
+receiving the peer assessment feedback as well as for the student giving it. Often
+those students who engage in effective peer assessment tasks become much more aware
+of how to improve their own work by virtue of trying to improve others'.
 
 Peer assessment engages your students in taking on the role of what Dylan William has called ‘learning resources for their peers’ and just as with self-assessment you'll need to provide students with exemplars and success criteria as well as planned opportunities to identify successes and areas for improvement and, crucially, planned opportunities to act on this information.
 

--- a/content/teach-first/year-1-what-makes-classroom-practice-effective/spring-week-2-ect-theory.md
+++ b/content/teach-first/year-1-what-makes-classroom-practice-effective/spring-week-2-ect-theory.md
@@ -74,14 +74,8 @@ In this part of the module we'll be exploring how Rosenshine reminds us to prese
 2. To clarify and expand an idea
 3. To give causes, context and consequences of a situation or event
 4. Or show how facts and concepts are related and connected
-   So effective explanations are hugely important. Tharby makes it crystal clear when
-   he says, ‘It is near impossible to conceive of effective teaching without explanation’.
-   Teacher talk is vital. If the children can't access our expertise through clear,
-   precise, knowledgeable explanations they are disadvantaged. And the evidence from
-   cognitive science shows that the less prior knowledge a pupil has, the more teacher
-   guidance they need. So, explanations are vital for the children we teach to make
-   sense of the world around them. It's hard, and again it takes lots of practice for
-   a novice teacher. But explanations illuminate.
+
+So effective explanations are hugely important. Tharby makes it crystal clear when he says, ‘It is near impossible to conceive of effective teaching without explanation’. Teacher talk is vital. If the children can't access our expertise through clear, precise, knowledgeable explanations they are disadvantaged. And the evidence from cognitive science shows that the less prior knowledge a pupil has, the more teacher guidance they need. So, explanations are vital for the children we teach to make sense of the world around them. It's hard, and again it takes lots of practice for a novice teacher. But explanations illuminate.
 
 In this session, you'll learn to start making links between what you know about working memory and effective explanations. Effective explanations are chunked. The teacher does not overwhelm pupils by presenting too much information at once, as the working memory can become overloaded. Information and new material are presented in small steps and often with many concrete examples. This is where modelling can come in: the importance of concrete examples so the children can see what a good or indeed a bad example looks like. As Tom Sherrington says, ‘providing models is a central feature of giving good explanations’. Models can be used in any phase of schooling and are an important element of the children having a concrete example of what it looks like. Weinstein and Sumeracki remind us that novices find abstract ideas vague and hard to grasp so concrete examples are much easier to remember. Models help to illustrate abstract ideas and make them easier to understand. Models can organize the information for the novice into a well-structured schema.
 

--- a/content/teach-first/year-1-what-makes-classroom-practice-effective/spring-week-5-ect-theory.md
+++ b/content/teach-first/year-1-what-makes-classroom-practice-effective/spring-week-5-ect-theory.md
@@ -35,18 +35,8 @@ Questioning is essential to great teaching and should be interactive and respons
 2. Ask students to explain what they have learned
 3. Check the response of all students
 4. Provide systematic feedback and corrections
-   So questioning helps us do a lot. It's essential to be a good questioner as a teacher
-   and again it needs lots and lots of practice. Our questions can help us gauge many
-   things, from how well the pupils understand, to whether we need to reteach something,
-   to whether pupils have understood a complex concept. We need to ask loads of questions
-   and involve loads of pupils. We may need to take more time in a lesson to explain
-   something further if our questioning has shown us that pupils don't really get it.
-   Questioning enables us to be responsive teachers and to act on the information we
-   glean from our pupils. Questioning is really key and, as Rosenshine found, less successful
-   teachers ask fewer questions and almost no process questions. There's an array of
-   questioning strategies that you can employ in your teaching. It's worth focusing
-   on a few and practicing them until you're more comfortable and they come more naturally.
-   Practice is key.
+
+So questioning helps us do a lot. It's essential to be a good questioner as a teacher and again it needs lots and lots of practice. Our questions can help us gauge many things, from how well the pupils understand, to whether we need to reteach something, to whether pupils have understood a complex concept. We need to ask loads of questions and involve loads of pupils. We may need to take more time in a lesson to explain something further if our questioning has shown us that pupils don't really get it. Questioning enables us to be responsive teachers and to act on the information we glean from our pupils. Questioning is really key and, as Rosenshine found, less successful teachers ask fewer questions and almost no process questions. There's an array of questioning strategies that you can employ in your teaching. It's worth focusing on a few and practicing them until you're more comfortable and they come more naturally. Practice is key.
 
 In this session you'll explore how to check pupils’ understanding by asking pupils a number of different questions and gaining feedback about what they understand. As Rosenshine and Sherrington emphasize, this reinforces the need to present material in small steps. If there's too much at once then errors and misconceptions will potentially occur more frequently. Therefore chunked explanations supported by models and reinforced by regular questioning and checking for understanding is vital.
 

--- a/content/ucl/year-1-enabling-pupil-learning/autumn-week-2-mentor-materials.md
+++ b/content/ucl/year-1-enabling-pupil-learning/autumn-week-2-mentor-materials.md
@@ -76,36 +76,24 @@ Be as specific as you can in the detail you give. The purpose of this activity i
 Theory to Practice: 35 mins
 
 1. Discussion with mentor
-
    Discuss with your mentee any routines that are mandated by your school’s behaviour policy and teaching and learning policy. Make reference to the relevant policies as appropriate and check that your mentee is clear about what is expected of them. This could include:
-
    - routines for moving around the school building
    - routines for managing behaviour
    - routines for organising teaching and learning (e.g. required components of lessons)
-
 2. Analyse artefacts/scripting
-
    Work with your mentee to review and refine their scripted entry routine for their classroom, drafted during this week’s self-directed study session.
-
    To support this process you could:
-
    - cross-reference the script to this week’s research and practice summary, checking to see how the script does/could draw on ideas drawn from best practice
    - cross-reference the script to your school’s policies and embedded routines
    - consider the characteristics of your mentee’s pupils and how these influence your mentee’s expectations
    - discuss how the routine might be altered to account for differences in pupil characteristics or contexts (e.g. how routines might be different for pupils in different key stages, or in different learning spaces)
    - ensure that the script is sufficiently detailed that it sets out clearly what is expected of pupils and how your mentee will clarify, model and embed these expectations
-
 3. Rehearsal
-
-   Having refined your mentee’s script/routine, work with them to rehearse the script in action.
-
-   To support this process you could:
-
+   Having refined your mentee’s script/routine, work with them to rehearse the script in action. To support this process you could:
    - play the part of a pupil entering your mentee’s classroom
    - give feedback on how closely your mentee’s enactment of their routine reflects their script
    - give feedback on how to improve enactment of the routine
    - ask your mentee to repeat the routine until they are able to enact it confidently and accurately
-
 4. If you have time you may wish to repeat the processes of scripting and rehearsal with another routine relevant to your mentee. This should be selected according to the phase and specialism of your mentee and their personal learning needs.
 
 ---

--- a/content/ucl/year-1-enabling-pupil-learning/autumn-week-3-mentor-materials.md
+++ b/content/ucl/year-1-enabling-pupil-learning/autumn-week-3-mentor-materials.md
@@ -65,34 +65,22 @@ To support the impact of this activity you should:
 Theory to Practice: 35 mins
 
 1. Discussion with mentor
-
    Discuss with your mentee what they saw in their observation and how this helps them to make sense of the research and practice summary in this week's ECT materials.
-
    You could address the following questions:
-
    - how do the strategies in use reflect the good practice outlined in the research and practice summary in this week's ECT materials?
    - how do the strategies in use reflect the characteristics of the pupils, the context of the class and the content being taught?
    - which strategies does your mentee already use in their own practice?
    - what would your mentee like to add to or change in their own practice, having completed this observation?
    - how do the strategies, sanctions and rewards observed reflect your school’s behaviour policy?
-
 2. Scripting
-
    Drawing on your discussion in activity 1, work with your mentee to script the details of a strategy that your mentee would like to add to their practice. This should draw on the content of the research and practice summary in this week's ECT materials.
-
    To make this as useful as possible, address these points as you complete this activity:
-
    - clarify explicitly the purpose of the strategy (e.g. gaining pupils’ attention, giving clear instructions for a common routine in the classroom)
    - be specific about whether this script is for use with all pupils, a specific pupil or group of pupils
    - make use of examples provided in the research and practice summary, adapting these as required for your mentee’s context and pupil characteristics
    - include within the script specific language that your mentee could use (e.g. rather than noting ‘I will use a standard routine for getting pupils’ attention’ you could note ‘I will count down from 3 with positive actions for pupils, saying, ‘3…stop writing, 2…pens down, 1…show me that you’re listening’)
-
 3. Rehearsal
-
-   Now work with your mentee to rehearse the strategy that has been scripted.
-
-   To support this process you can:
-
+   Now work with your mentee to rehearse the strategy that has been scripted. To support this process you can:
    - play the part of a pupil and ‘act back’ appropriately to help your mentee rehearse the strategy
    - give feedback on how well your mentee’s rehearsal aligns with the script as planned in activity 2 (this could include non-verbal aspects as well as the words spoken)
    - highlight aspects of strength in your mentee’s performance, connecting these to this week’s research and practice summary

--- a/content/ucl/year-1-enabling-pupil-learning/autumn-week-5-mentor-materials.md
+++ b/content/ucl/year-1-enabling-pupil-learning/autumn-week-5-mentor-materials.md
@@ -50,33 +50,22 @@ At the start of this module, you looked at all of the _learn how to_ statements 
 Theory to Practice: 35 mins
 
 1. Analyse artefacts/discuss with mentor
-
    Review the vignettes that your mentee drafted in their self-study session this week. Use your knowledge and experience to discuss with your mentee why this sort of in-depth reflection on pupils is valuable, including why it is a necessary starting point for teachers who want to develop their pupils as independent, self-regulating learners.
-
    To support this activity, you could:
-
    - highlight strengths and areas for development in how your mentee has approached the vignettes
    - if you know the pupils concerned, help your mentee to expand the vignettes by drawing on your knowledge of the pupils
    - discuss possible strategies that would help your mentee come to know their pupils better over time so that they are in a position to understand more about their resilience, self-regulation and motivation
    - discuss the value for teachers of undertaking activities like this one, in helping them to reflect on the progress of individual learners in their class(es)
-
 2. Collaborative planning
-
    Use the notes made by your mentee in their self-study session and the outcomes of the first activity in this session as a starting point for some collaborative planning. Work with your mentee to plan how they will incorporate into their teaching in the coming week strategies for developing pupils’ resilience, self-regulation and motivation.
-
    As you work through this activity, you could:
-
    - check that your mentee is clear about whether they are focusing on a single pupil, a group of pupils or a whole class
    - connect the strategies they select to their understanding of the relative strengths and areas for development of the pupil(s) selected
    - relate planning back to the research and practice summary in this week's ECT materials, and the strategies identified that help to develop pupils as independent learners
    - encourage your mentee to be specific in detailing the actions they will take, including scripting any key interactions with pupils that would benefit from this level of detailed preparation
-
 3. Rehearsal
-
    As appropriate, support your mentee to rehearse key interactions that will be part of their teaching as they put their planned strategies into practice.
-
    You can support your mentee’s learning in this activity by:
-
    - taking the role of the pupil(s) concerned and ‘acting back’ as they typically might so that your mentee can rehearse their chosen strategy
    - giving feedback to your mentee about how well they enacted their planned strategy, including positive steps to improve their practice
 

--- a/content/ucl/year-1-enabling-pupil-learning/autumn-week-6-mentor-materials.md
+++ b/content/ucl/year-1-enabling-pupil-learning/autumn-week-6-mentor-materials.md
@@ -45,32 +45,21 @@ At the start of this module, you looked at all of the _learn how to_ statements 
 Theory to Practice: 35 mins
 
 1. Analyse artefacts/discuss with mentor
-
    Invite your mentee to talk you through the vignettes and checklist they drafted in their self-study session this week and to share what they learned from completing these activities. Use your knowledge and experience to highlight strengths in your mentee’s reflective thinking and suggest ways to make the most of their learning from the activities as they put their checklist into practice.
-
    To support this discussion, you could:
-
    - connect your mentee’s checklist to your school’s behaviour policy to ensure that the two are aligned
    - highlight strengths in your mentee’s current approach to managing behaviour on which they can build
    - note any areas for development which your mentee has not included in their checklist, but which you think should usefully be addressed
-
 2. Discuss with mentor
-
    Module 1 has introduced a range of approaches to behaviour management, many of which your mentee will now have put into practice. As part of next week’s ECT mentor meeting, you will observe your mentee using some of these approaches. Based on your mentee’s development needs and the challenges they are currently experiencing with their pupils, agree with your mentee which class you will observe and the focus of this observation. The observation is allocated 20 minutes of your meeting time for the week.
-
    Use the notes made by your mentee in their self-study session and the outcomes of the first activity in this session as a starting point for some collaborative planning. Work with your mentee to plan how they will incorporate into their teaching, in the coming week, strategies for developing pupils’ resilience, self-regulation and motivation.
-
    Agree with your mentee:
-
    - which lesson you will observe
    - which 20 minute part of the lesson you will observe
    - the focus of your observation, drawn from one or more of the sessions for Module 1
    - the success criteria for this observation, contextualised for your mentee’s stage of development and the characteristics of their pupils
-
    Note: this observation should not form part of your school’s performance management process or NQT statutory induction. To clearly differentiate this developmental observation from these formal processes you may wish to record your observation notes on paperwork not associated with these processes.
-
 3. Collaborative planning
-
    Spend some time with your mentee planning their lesson for the agreed observation next week. Make use of research and practice summaries from previous weeks in this module, as appropriate, to stimulate ideas for the lesson. You might also use scripting and/or rehearsal if this suits your mentee’s needs.
 
 Next Steps: 5 mins

--- a/content/ucl/year-1-enabling-pupil-learning/autumn-week-7-mentor-materials.md
+++ b/content/ucl/year-1-enabling-pupil-learning/autumn-week-7-mentor-materials.md
@@ -43,31 +43,21 @@ Remember that this observation is separate from your school’s formal NQT induc
 Theory to Practice 30 mins
 
 1. Reflection
-
    Ask your mentee to reflect on the lesson that you observed. This is an opportunity for you to support the development of their reflective capacity with good judgement, and in relation to evidence and best practice, and to set appropriate targets for their ongoing development.
-
    To support your mentee’s reflection you could prompt them to:
-
    - identify strengths in their teaching in relation to the strategies they planned to use in the session – in enacting the strategies as planned and in adapting these to the requirements of the lesson
    - identify areas for development, as above
    - consider any aspects of the lesson which surprised them and how this will help them to plan more effective teaching in the future
    - connect their practice in the lesson to research and practice summaries in this module. Where did they demonstrate particular strategies from these summaries? How can they further embed these strategies in their practice over time?
-
    Use your judgment to support and shape your mentee’s reflections, as appropriate.
-
 2. Discuss with mentor –share your feedback on your mentee’s lesson.
-
    To make productive use of this discussion, you could:
-
    - use your notes from the observation to highlight strengths in your mentee’s practice – both in enacting the strategies that were planned and in responding to what happened in the lesson as it progressed
    - use your notes to highlight opportunities for further development in your mentee’s practice, as above
    - build on relevant points arising from your mentee’s reflections in the previous activity
    - connect your feedback explicitly to the contents of the research and practice summaries from this module
-
 3. Reflection
-
    Return to the module audit that your mentee completed at the beginning of this module. Invite your mentee to complete this audit again, having worked through the module. You could:
-
    - note and celebrate those areas in which your mentee has made progress
    - recognise those areas in which your mentee is finding it more difficult to make progress and discuss how you will continue to support your mentee to do this over time
    - acknowledge with your mentee that they will continue to develop their competence and confidence in relation to Module 1 contents as they gain experience. Remind them that they can return to module materials at a later stage if they experience particular challenges related to setting high expectations and managing behaviour effectively

--- a/content/ucl/year-1-engaging-pupils-in-learning/autumn-week-2-mentor-materials.md
+++ b/content/ucl/year-1-engaging-pupils-in-learning/autumn-week-2-mentor-materials.md
@@ -66,26 +66,17 @@ At the start of this module, you looked at all of the ‘learn how to’ stateme
 Theory to Practice 40 mins
 
 1. Collaborative planning
-
    Jointly work through your mentee’s lesson plan from their last self-directed session incorporating working memory/long-term memory exchange. They had Hasan’s Year 9 English lesson to work from as a model. Work together to explore how this might be refined in order to avoid cognitive overload to working memory and maximise learning.
-
    To support this exploration of their lesson you might like to ask:
-
    - Do you think your pupils, or some of them, might find this too hard?
    - If so, could it be because their working memory is overloaded – you are asking them to handle too many ‘bits’ of knowledge at once?
    - Have you done enough to help your pupils to retrieve knowledge from their long-term memories?
-
 2. Discuss with mentor
-
    Briefly discuss with your mentee their ideas about:
-
    - how to identify when prior knowledge is weak and pupils have misconceptions
    - what strategies might be effective for their class(es) in anticipating and dealing with these misconceptions
-
    Focusing specifically on an instance of misconception that your mentee has encountered, jointly work through their ideas and how these might be refined in order to minimise the occurrence of this.
-
    To support this discussion, you could refer to the research and practice summary in this week's ECT materials, and use perhaps two of these prompts:
-
    - consider how they might discover the likely extent of this misconception, both across their class as a whole and among different pupils (e.g. do a quick quiz of their previous learning, get pupils to rehearse ‘everything they remember’, give a quick recap of what they ought to have learned and follow up with one or two multiple-choice questions, ‘correct the teacher’ – deliberately quote the likely misconception and challenge the class to point out the mistake)
    - draw out implications of this discussion for what – and how – new material might be introduced
    - building on their understanding of the role of memory in learning, map out a strategy for addressing misconceptions that could be used within their classroom, including providing appropriate external support and thinking about what form this should take
@@ -98,9 +89,7 @@ Next Steps 5 mins
 Agree with your mentee how they will now put their learning from this week’s session(s) into practice in their teaching. Help your mentee to clarify:
 
 1. the action(s) they will take and how these action(s) are expected to contribute to improving their workload and wellbeing
-
 2. what success will ‘look like’ in relation to these action(s)
-
 3. how they will evaluate their success in taking these action(s)
 
 Note the date of your next mentor meeting, when you will check on your mentee’s progress.

--- a/content/ucl/year-1-engaging-pupils-in-learning/autumn-week-3-mentor-materials.md
+++ b/content/ucl/year-1-engaging-pupils-in-learning/autumn-week-3-mentor-materials.md
@@ -40,30 +40,19 @@ Clarify the learning intentions for this session with your mentee. These are ext
 Theory to Practice 40 mins
 
 1. Discuss with Mentor
-
    Your mentee observed or had a discussion with a colleague who has some expertise in literacy. Review with them how the observation or discussion went and help them to draw out important learning for themselves. If they have not managed to do it yet, you should help them to arrange the observation or discussion and make sure it happens.
-
    To support you in having a focused discussion, you might frame it this way with your mentee:
-
    ‘I believe you have observed/ met a colleague who has expertise in literacy.
-
-   How far did they address: <br/>
-
-   - explicitly teaching unfamiliar and high-utility vocabulary <br/>
-   - modelling reading comprehension by asking questions, making predictions, and summarising <br/>
-   - promoting reading for pleasure <br/>
-   - modelling and requiring high-quality oral language. <br/>
-
+   How far did they address:
+   - explicitly teaching unfamiliar and high-utility vocabulary
+   - modelling reading comprehension by asking questions, making predictions, and summarising
+   - promoting reading for pleasure
+   - modelling and requiring high-quality oral language.
    What is the single-most important thing that you learned from this? What would you need to do to apply what you have learned in your own teaching? What support from me, or others, might you need?’
-
 2. Collaborative planning
-
    Work together with the mentee to plan a lesson or sequence of lessons which seek to develop a specific area of literacy pertinent to their subject or phase.
-
    For example, the mentee may have focused their self-study on the role of oral language in literacy development. They might have observed how a teacher has supported a positive climate for constructive dialogue, perhaps through the use of ground rules or sentence stems to scaffold pupil talk.
-
    The examples provided in the self-study session are shown below.
-
    Support their reflections and plan together how they will apply their learning to their own practice over the next few lessons
 
 ### Learning intention: Demonstrating a clear understanding of systematic synthetic phonics, particularly if teaching early reading and spelling.

--- a/content/ucl/year-1-engaging-pupils-in-learning/autumn-week-4-mentor-materials.md
+++ b/content/ucl/year-1-engaging-pupils-in-learning/autumn-week-4-mentor-materials.md
@@ -51,67 +51,48 @@ Throughout the session, try to refer explicitly to the Learning Intentions, and 
 Review and Plan 5 mins
 
 1. Start this session by briefly following up the actions that the mentee set at the end of last week’s session, which was to do some planning around consolidation, retrieval and spaced practice (inspired by Bob’s science lesson). Ask your mentee to summarise:
-
    a. what they did
-
    b. the impact of this on pupil learning (including how they are evaluating this)
-
    c. what they will do going forward to build on these actions
-
 2. Clarify the Learning Intentions for this session with your mentee.
-
    At the start of this module, you looked at all of the learn how to statements for Standards 2 and 3 and conducted a module audit with your mentee: in some areas they will already be confident and skilled; in others they will want more practice, and support from you and others. Look back at this audit now and use it to help decide how you and your mentee will make the most productive use of the suggested Theory to Practice activities below.
 
 Theory to Practice 40 mins
 
 1. Discuss with Mentor
-
    Based on their reading of the research and practice summary in this week's ECT materials, discuss with your mentee their understanding of:
-
    - how consolidation of memory takes place through repeated experiences of events such as related problem-solving exercises
    - how this process is supported by regular review/retrieval, external coding, and spaced practice
-
    They may also want to discuss with you other questions that arose from their reading.
-
    To support this discussion, it might be helpful to remember that consolidation of memory is an important part of learning, whether the pupil is building their fact-based knowledge or they are honing their practical or artistic skills. The more they recall their memory, the more they can habituate the skill or call the concepts to mind with ease. This applies to a wide range of learning types, including: setting your body to catch a ball; multiplication rules; neat handwriting; common everyday phrases in a foreign language.
-
 2. Collaborative planning and sharing of practice
-
    Jointly work through your mentee’s lesson plan from their last self-directed session incorporating consolidation strategies, and how this might be refined to provide a balanced mix of support over a sequence of lessons.
-
    To support this collaboration, you might:
 
-   a) Consider the specific range and sequence of strategies to support consolidation (review/ retrieval, worked examples, external cueing, spaced practice) that they have mapped out for their lesson plan, and how these might fit together.
+   1. Consider the specific range and sequence of strategies to support consolidation (review/ retrieval, worked examples, external cueing, spaced practice) that they have mapped out for their lesson plan, and how these might fit together.
+      Here are some useful prompts:
+      - Is the balance right, or are they trying to do too much or too little?
+      - If they intend to use spacing between targeted practice, have they thought about what they will teach in the intervals?
+      - Have they thought about how their strategies will affect pupils in their class with differing prior attainment? (They may be able to withdraw scaffolded support for some pupils more quickly than others.)
 
-   Here are some useful prompts:
-
-   - Is the balance right, or are they trying to do too much or too little?
-   - If they intend to use spacing between targeted practice, have they thought about what they will teach in the intervals?
-   - Have they thought about how their strategies will affect pupils in their class with differing prior attainment? (They may be able to withdraw scaffolded support for some pupils more quickly than others.)
-
-   b) Map out a more extended sequence of strategies to be applied across a series of lessons. Here are some prompt questions that you can use:
-
-   - Should some strategies be used earlier and others later? E.g. repeating or changing the cues.
-   - If so, what should be introduced when, and why?
-   - When should scaffolds be reduced, and for whom?
-   - How might the mentee tell when their pupils are ready for this?
-   - What will your mentee teach in the intervals between any spaces they decide to introduce between practice?
-   - How would your mentee know that their pupils have secured their learning?
+   2. Map out a more extended sequence of strategies to be applied across a series of lessons. Here are some prompt questions that you can use:
+     - Should some strategies be used earlier and others later? E.g. repeating or changing the cues.
+     - If so, what should be introduced when, and why?
+     - When should scaffolds be reduced, and for whom?
+     - How might the mentee tell when their pupils are ready for this?
+     - What will your mentee teach in the intervals between any spaces they decide to introduce between practice?
+     - How would your mentee know that their pupils have secured their learning?
 
    c) As part of the discussion, share and reflect on examples from your own or another teacher’s planning and activity. Explain to your mentee the key decisions you made about sequencing teaching over a number of lessons, and the most important factors influencing these decisions. For example, if you are teaching practical or physical skills, you might talk about how you get your pupils to learn, remember and practise these skills over time. By modelling your reasoning process, you are helping your mentee to shape their own thought processes around planning.
-
 3. Reflection
-
    Ask your mentee to reflect on their learning in this session and how they will apply this to their practice going forward. Encourage them to consolidate this learning into a series of prompts or ‘key learning points’ which they can use to help improve their lesson planning and teaching as they continue to develop.
 
 Next Steps 5 mins
 
 Agree with your mentee how they will now put their learning from this week’s session(s) into practice in their teaching. Help your mentee to clarify:
 
-1\. the action(s) they will take and how these action(s) are expected to contribute to improving their workload and wellbeing
-
-2\. what success will ‘look like’ in relation to these action(s)
-
-3\. how they will evaluate their success in taking these action(s)
+1. the action(s) they will take and how these action(s) are expected to contribute to improving their workload and wellbeing
+2. what success will ‘look like’ in relation to these action(s)
+3. how they will evaluate their success in taking these action(s)
 
 Note the date of your next mentor meeting, when you will check on your mentee’s progress.

--- a/content/ucl/year-1-engaging-pupils-in-learning/autumn-week-5-mentor-materials.md
+++ b/content/ucl/year-1-engaging-pupils-in-learning/autumn-week-5-mentor-materials.md
@@ -36,13 +36,9 @@ Throughout the session, try to refer explicitly to the Learning Intentions, and 
 Review 5 mins
 
 1. Start this session by briefly following up the actions that the mentee set at the end of last week’s session, which was to plan a lesson which retained core knowledge but also introduced values important to your mentee. Ask your mentee to summarise:
-
-   a. what they did
-
-   b. the impact of this on pupil learning (including how they are evaluating this)
-
-   c. what they will do going forward to build on these actions
-
+   1. what they did
+   2. the impact of this on pupil learning (including how they are evaluating this)
+   3. what they will do going forward to build on these actions
 2. Clarify the Learning Intentions for this session with your mentee
 
 Plan 5 mins
@@ -54,18 +50,12 @@ Theory to Practice 35 mins
 Your mentee had the exemplification of Rachel’s Year 6 PE lesson (above) to help model their own topic plan.
 
 1. Analyse artefacts
-
    Discuss with your mentee the topic planning that they devised in their self-directed study this week.
-
    To support your discussion of their plan, ask your mentee to articulate their thinking on the questions below. (And help them to extend and refine their thinking with the prompts that follow.)
-
-   a. What are the key knowledge and skills within this topic? (And how could you communicate these to your pupils?)
-
-   b. What educational values are supported within this topic? (And why are these important to you?)
-
-   c. How does the topic draw on understanding of prior knowledge to sequence the content within the lessons (and any home learning), including key points of assessment? (Is their prior knowledge secure? Are they making common errors still?)
-
-   d. How are critical skills and transfer considered within the planning? (And can you use a rule-of-thumb like EAR to help develop schema?)
+   1. What are the key knowledge and skills within this topic? (And how could you communicate these to your pupils?)
+   2. What educational values are supported within this topic? (And why are these important to you?)
+   3. How does the topic draw on understanding of prior knowledge to sequence the content within the lessons (and any home learning), including key points of assessment? (Is their prior knowledge secure? Are they making common errors still?)
+   4. How are critical skills and transfer considered within the planning? (And can you use a rule-of-thumb like EAR to help develop schema?)
 
 2. Collaborative planning
 
@@ -81,11 +71,9 @@ Next Steps 5 mins
 
 Agree with your mentee how they will now put their learning from this week’s session(s) into practice in their teaching. Help your mentee to clarify:
 
-1\. the action(s) they will take and how these action(s) are expected to contribute to improving their workload and wellbeing
-
-2\. what success will ‘look like’ in relation to these action(s)
-
-3\. how they will evaluate their success in taking these action(s)
+1. the action(s) they will take and how these action(s) are expected to contribute to improving their workload and wellbeing
+2. what success will ‘look like’ in relation to these action(s)
+3. how they will evaluate their success in taking these action(s)
 
 Note the date of your next mentor meeting, when you will check on your mentee’s progress.
 

--- a/content/ucl/year-1-engaging-pupils-in-learning/autumn-week-6-mentor-materials.md
+++ b/content/ucl/year-1-engaging-pupils-in-learning/autumn-week-6-mentor-materials.md
@@ -88,12 +88,9 @@ Throughout the session, try to refer explicitly to the Learning Intentions, and 
 Review 5 mins
 
 1. Start this session by briefly following up the actions that the mentee set at the end of last week’s session, which was to plan learning which combined opportunities to develop critical thinking and transfer, while expressing something important about the values inherent in the subject. Ask your mentee to summarise:
-
-   a. what they did
-
-   b. the impact of this on pupil learning (including how they are evaluating this)
-
-   c. what they will do going forward to build on these actions
+  1. what they did
+  2. the impact of this on pupil learning (including how they are evaluating this)
+  3. what they will do going forward to build on these actions
 
 2. Clarify the Learning Intentions for this session with your mentee
 
@@ -106,31 +103,18 @@ Theory to Practice 35 mins
 Last week, your mentee thought in depth about one topic. The topic will have been drawn from a discipline, such as literacy or a subject, such as geography. Your mentee might have instead focused on a skill or development goal, such as fine motor skills or collaborative play. For ease, we will just refer here to ‘subjects’. Even if your mentee teaches across a range of subjects, in this session they are thinking about just one. By modelling the depth of thought that is possible in relation to this one subject, you are preparing your mentee to think this deeply about each subject that they may teach.
 
 1. Discuss with mentor
-
    With your mentee, discuss why your chosen subject ‘really matters’. Why do you feel that it is deserving of the space given to it in the school curriculum?
-
    To guide your discussion, use these prompts. Don’t aim to cover all prompts, but focus on those which are most relevant to your mentee, the phase in which they teach and the subject being discussed.
-
-   a. Develop a list of key concepts and skills within your chosen area together. It might help to first consider the parent discipline(s) from which the subjects are derived (e.g. literacy in English derives from English language; school geography also draws on geology, environmental science, urban planning, etc.)
-
-   - What might be learnt at university about this discipline (or skill/development goal)?
-   - What is cutting edge within this area which has perhaps not been brought into school curricula yet? (e.g. recent advances in space exploration, the release of a new music album, the design features of a new smartphone)
-   - What makes your mentee (and you as a mentor) passionate about this area?
-
-   b. To help with this task you might use further internet research, for example, by looking at university subject department websites or any professional associations and societies associated with the subject (e.g. the Royal Geographical Society, Historical Association, Institute of Physics)
-
-   c. Together with your mentee now try to define the nature of the subject that you are focusing on: how does it provide students with knowledge about the world, or ways of acting within it? (For example, art can provide representations of the world, but it can also challenge, provoking thought and emotion. Mathematics also provides a language with which to describe the world, but it goes further in that it allows us to see patterns that we might not otherwise be aware of, because it is an internally coherent language. Physical education teaches pupils about recreation, but also teamwork, health and the human body, drawing on both the experience of accomplished sportspersons and scientific study.)
-
+   1. Develop a list of key concepts and skills within your chosen area together. It might help to first consider the parent discipline(s) from which the subjects are derived (e.g. literacy in English derives from English language; school geography also draws on geology, environmental science, urban planning, etc.)
+    - What might be learnt at university about this discipline (or skill/development goal)?
+    - What is cutting edge within this area which has perhaps not been brought into school curricula yet? (e.g. recent advances in space exploration, the release of a new music album, the design features of a new smartphone)
+    - What makes your mentee (and you as a mentor) passionate about this area?
+   2. To help with this task you might use further internet research, for example, by looking at university subject department websites or any professional associations and societies associated with the subject (e.g. the Royal Geographical Society, Historical Association, Institute of Physics)
+   3. Together with your mentee now try to define the nature of the subject that you are focusing on: how does it provide students with knowledge about the world, or ways of acting within it? (For example, art can provide representations of the world, but it can also challenge, provoking thought and emotion. Mathematics also provides a language with which to describe the world, but it goes further in that it allows us to see patterns that we might not otherwise be aware of, because it is an internally coherent language. Physical education teaches pupils about recreation, but also teamwork, health and the human body, drawing on both the experience of accomplished sportspersons and scientific study.)
 2. Practical activity
-
    Within any area of learning there are stories and analogies, illustrations, examples, explanations and demonstrations which convey the important knowledge and skills. Some of these may have come up when you were discussing progression over the last two weeks.
-
    Either
-
-   1. If you feel that you arrived at a reasonable definition for the nature of the subject that you are discussing, now spend time listing the activities and explanations which already convey this to students within your curriculum. How do students come to understand the nature of this subject? How can teachers support this further? (e.g. if you are teaching art, are there opportunities for your pupils to go beyond painting a ‘good’ picture, so that they make art that ‘says’ something? In maths, do you invite your pupils to see the mathematical patterns that occur around them?)
-
-      Or
-
+   1. If you feel that you arrived at a reasonable definition for the nature of the subject that you are discussing, now spend time listing the activities and explanations which already convey this to students within your curriculum. How do students come to understand the nature of this subject? How can teachers support this further? (e.g. if you are teaching art, are there opportunities for your pupils to go beyond painting a ‘good’ picture, so that they make art that ‘says’ something? In maths, do you invite your pupils to see the mathematical patterns that occur around them?), or
    2. If consideration of the nature of the subject under discussion was challenging (and indeed this often is), then instead spend some time focusing on a key concept or skill. List the activities and explanations that allow understanding of this to build up across a year.
 
 3. Collaborative planning
@@ -161,11 +145,9 @@ Next Steps 5 mins
 
 Agree with your mentee how they will now put their learning from this week’s session(s) into practice in their teaching. Help your mentee to clarify:
 
-1\. the action(s) they will take and how these action(s) are expected to contribute to improving their workload and wellbeing
-
-2\. what success will ‘look like’ in relation to these action(s)
-
-3\. how they will evaluate their success in taking these action(s)
+1. the action(s) they will take and how these action(s) are expected to contribute to improving their workload and wellbeing
+2. what success will ‘look like’ in relation to these action(s)
+3. how they will evaluate their success in taking these action(s)
 
 Note the date of your next mentor meeting, when you will check on your mentee’s progress.
 

--- a/content/ucl/year-1-engaging-pupils-in-learning/autumn-week-7-mentor-materials.md
+++ b/content/ucl/year-1-engaging-pupils-in-learning/autumn-week-7-mentor-materials.md
@@ -35,13 +35,9 @@ As this session is an opportunity for reflection there is no additional research
 Review 5 mins
 
 1. Start this session by briefly following up the actions that the mentee set at the end of last week’s session. Ask your mentee to summarise:
-
-   a. what they did
-
-   b. the impact of this on pupil learning (including how they are evaluating this)
-
-   c. what they will do going forward to build on these actions
-
+  1. what they did
+  2. the impact of this on pupil learning (including how they are evaluating this)
+  3. what they will do going forward to build on these actions
 2. Clarify the Learning Intentions for this session with your mentee
 
 Plan 5 mins
@@ -102,10 +98,8 @@ Next Steps 5 mins
 
 Agree with your mentee how they will now put their learning from this week’s session into practice in their teaching. Help your mentee to clarify:
 
-1\. the action(s) they will take and how these action(s) are expected to contribute to improving their workload and wellbeing
-
-2\. what success will ‘look like’ in relation to these action(s)
-
-3\. how they will evaluate their success in taking these action(s)
+1. the action(s) they will take and how these action(s) are expected to contribute to improving their workload and wellbeing
+2. what success will ‘look like’ in relation to these action(s)
+3. how they will evaluate their success in taking these action(s)
 
 Note the date of your next mentor meeting.

--- a/content/ucl/year-1-first-half-term-developing-quality-pedagogy-part-1/spring-week-5-ect-research-and-practice-summary.md
+++ b/content/ucl/year-1-first-half-term-developing-quality-pedagogy-part-1/spring-week-5-ect-research-and-practice-summary.md
@@ -77,12 +77,9 @@ I put pupils into groups of mixed ability based on how they had tackled their pr
 We used the following scaffold to structure discussion. 'What would success look like for Henry VIII in terms of his foreign policy 1509–1527?’
 
 1. Suggest a definition for success.
-
 2. Ask a question about the definition. Person 1 should respond to your
    question.
-
 3. Suggest a change to the definition in the light of this discussion.
-
 4. Ask a further question about the definition and then draft a final
    definition which the whole group should then agree before all writing down
    an answer.

--- a/content/ucl/year-1-first-half-term-developing-quality-pedagogy-part-1/spring-week-5-mentor-materials.md
+++ b/content/ucl/year-1-first-half-term-developing-quality-pedagogy-part-1/spring-week-5-mentor-materials.md
@@ -43,45 +43,29 @@ Collaborative Planning
 Now, use their plan in this activity. Depending on the areas for further development that you identified with your mentee in their audit of Standard 4, select from the following activities:
 
 1. Planning activities around what you want pupils to think hard about.
-
    Explore the key learning intention for this lesson. What is it that pupils will need to work hard on and think hard about in order to make progress?
-
    Planning such activities means you should consider:
-
    - the different starting points of each pupil – will they all be thinking hard and working hard on the same thing?
    - what scaffolds you should introduce or withdraw
    - what pupil groupings will best support them
    - the opportunities you give your pupils to practise independently
-
    Are there any ideas you can borrow from the example of Sarah and her Year 11 geographers?
-
 2. Considering the factors that will support effective collaborative or paired work (e.g. familiarity with routines, whether pupils have the necessary prior knowledge and how pupils are grouped).
-
    It might be helpful to think of long-, medium- and short-term factors. Can your mentee say ‘yes’ to these?
-
    Long term factors:
-
    - I have agreed routines, and these are clear to all
    - The pupils have secure prior knowledge from earlier lessons
    - The pupils are used to working in different groups
-
    Medium term factors:
-
    - We have practised paired and collaborative work recently, where I reinforced expectations
    - The class has recently revisited some of the material they will need in this lesson
-
    Short term factors:
-
    - I am clear about my learning intentions for this lesson
    - I am clear about which pupils will work effectively together to achieve the learning intentions
    - I will start with a retrieval exercise so the pupils’ working memories are not overloaded
-
 3. Providing scaffolds for pupil talk to increase the focus and rigour of dialogue
-
    Firstly, look again at the research and practice summary in this week's ECT materials for strategies you can use and at the example of Sarah’s Year 11 geography class or Ben’s Year 12 history class.
-
    You could also consider smaller group and paired structures:
-
    - think-pair-share (thinking alone, sharing with a partner, sharing with a larger group)
    - specific roles for each member of the group (speaker, note-taker, challenger, checker)
    - scaffolds for the conversation – Pupil A explain..... Pupil B....; ABCQ (Agree, Build, Challenge, Question)

--- a/content/ucl/year-1-fulfilling-professional-responsibilities/summer-week-2-mentor-materials.md
+++ b/content/ucl/year-1-fulfilling-professional-responsibilities/summer-week-2-mentor-materials.md
@@ -87,43 +87,30 @@ Throughout the session, try to refer explicitly to the Learning Intentions, and 
 
 Review and Plan: 10 mins
 
-1 - Start this session by allocating some time for you and your mentee to read this week’s research and practice summary.
-
-2 - Clarify the learning intentions for this session with your mentee.
+1. Start this session by allocating some time for you and your mentee to read this week’s research and practice summary.
+2. Clarify the learning intentions for this session with your mentee.
 
 At the start of this module, you looked at all of the _learn how_ statements for Standard 8 and conducted a module audit with your mentee. In some areas they will already be confident and skilled. In others they will want more practice and support from you and others. Look back at this audit now and use it to help decide how you and your mentee will make the most productive use of the suggested Theory to Practice activities below.
 
 Theory to Practice: 35 mins
 
 1. Discuss with mentor
-
    Talk to your mentee about the issues and strategies raised in this week’s research and practice summary, and how they apply to your mentee at present.
-
    You could explore the following questions:
-
    - which issues explored in the summary are particularly pertinent for your mentee?
    - what strategies does your mentee already use successfully to manage their workload and wellbeing?
    - what, specifically, are the top 2 or 3 issues your mentee finds most challenge their workload and wellbeing?
    - are there patterns to how these issues present themselves? For example, are they linked to their timetable, to weekly/monthly/termly cycles in the school calendar/other?
-
 2. Sharing of practice
-
    Share with your mentee strategies you have used, or seen colleagues use, that specifically address the challenges your mentee has highlighted.
-
    As you share these examples:
-
    - be as specific as you can about the nature of the issue, the actions taken and the impact of these actions on workload and wellbeing
    - connect back to the principles/strategies identified in the research and practice summary above
-
 3. Analysis of artefacts/collaborative planning
-
    With reference to the mentee’s planner, online calendar and/or other approaches to planning their workload, work together to devise practical strategies that:
-
    - address the issues that most challenge their workload and wellbeing at present
    - proactively help to pre-empt issues that may challenge workload and wellbeing in the future
-
    To make the most of this activity:
-
    - build on the positive strategies your mentee already has in place
    - draw on the successful strategies that you have shared from your own practice and that of colleagues
    - prompt your mentee to be as specific as possible in setting out the strategies they will put in place going forward. For example, if they are committing to at least one evening a week when they will not work beyond 5pm, use their planner to identify a day when this is most feasible/beneficial and encourage them to add this to their planner as a reminder

--- a/content/ucl/year-1-making-productive-use-of-assessment/summer-week-3-mentor-materials.md
+++ b/content/ucl/year-1-making-productive-use-of-assessment/summer-week-3-mentor-materials.md
@@ -35,11 +35,9 @@ Throughout the session, try to refer explicitly to the Learning Intentions, and 
 Review: 5 mins
 
 1. Start this session by briefly following up on the actions that your mentee set at the end of last week’s session. Ask your mentee to summarise:
-
-   - what they did
-   - the impact of this on pupil learning (including how they are evaluating this)
-   - what they will do going forward to build on these actions
-
+  - what they did
+  - the impact of this on pupil learning (including how they are evaluating this)
+  - what they will do going forward to build on these actions
 2. Clarify the Learning Intentions for this session with your mentee.
 
 Plan: 5 mins
@@ -63,11 +61,8 @@ To support this conversation, you could:
 Discuss with mentor / sharing of practice – discuss with your mentee:
 
 1. How they might use assessments in their phase/specialism at the beginning of new topics as a way of checking for prior knowledge/skill and pre-existing misconceptions. Share examples of your practice as appropriate to support this discussion.
-
    You might find it helpful to draft with your mentee a list of the most common misconceptions that you have encountered in your teaching, if you are experienced in the same phase/specialism as your mentee. If you work in a different phase/specialism, you may wish to seek input for this activity from a suitably experienced colleague.
-
 2. How to plan and use carefully structured questions during lessons that surface pupils’ thinking and enable the teacher to accurately identify knowledge gaps and misconceptions. Explore how hinge questions and elaboration might be used in the mentee’s phase and specialism to support assessment and therefore pupils’ learning. Share examples of your practice as appropriate to support this discussion.
-
    As above, you may find it helpful to seek input from a suitably experienced colleague if you work in a different phase / specialism to your mentee.
 
 ---

--- a/content/ucl/year-1-making-productive-use-of-assessment/summer-week-4-mentor-materials.md
+++ b/content/ucl/year-1-making-productive-use-of-assessment/summer-week-4-mentor-materials.md
@@ -38,11 +38,9 @@ Throughout the session, try to refer explicitly to the Learning Intentions, and 
 Review: 5 mins
 
 1. Start this session by briefly following up the actions that the mentee set at the end of last week’s session. Ask your mentee to summarise:
-
    - what they did
    - the impact of this on pupil learning (including how they are evaluating this)
    - what they will do going forward to build on these actions
-
 2. Clarify the Learning Intentions for this session with your mentee.
 
 Plan: 5 mins

--- a/content/ucl/year-1-second-half-term-developing-quality-pedagogy-part-2/spring-week-4-ect-self-study-activities.md
+++ b/content/ucl/year-1-second-half-term-developing-quality-pedagogy-part-2/spring-week-4-ect-self-study-activities.md
@@ -34,8 +34,6 @@ Bring these notes to your next mentor meeting.
 
 Look ahead to your next mentor meeting, where you will learn how to:
 
-5h. Make use of well-designed resources (e.g. textbooks).
-
-5i. Plan to connect new content with pupils’ existing knowledge or provide additional pre-teaching if pupils lack critical knowledge.
-
-5j. Build in additional practice or remove unnecessary expositions.
+- 5h. Make use of well-designed resources (e.g. textbooks).
+- 5i. Plan to connect new content with pupils’ existing knowledge or provide additional pre-teaching if pupils lack critical knowledge.
+- 5j. Build in additional practice or remove unnecessary expositions.

--- a/content/ucl/year-2-inquiry-into-developing-quality-pedagogy-and-making-productive-use-of-assessment-part-1/spring-week-1-mentor-materials.md
+++ b/content/ucl/year-2-inquiry-into-developing-quality-pedagogy-and-making-productive-use-of-assessment-part-1/spring-week-1-mentor-materials.md
@@ -64,7 +64,7 @@ Secure: I know a lot about this, and / or I do it in my practice consistently an
 
 Plan and Theory to Practice 40 mins
 
-1. Discuss with mentor
+## Discuss with mentor
 
 Ask your mentee to talk you through their audit and to explain the reasoning behind each self-assessment. Where possible, prompt the mentee to support their assessment with reference to one or more sources of evidence (see examples listed in the introduction to this session). You might use questions / prompts such as:
 
@@ -75,7 +75,7 @@ Ask your mentee to talk you through their audit and to explain the reasoning beh
 
 Use your expertise and experience to shape the mentee’s reflections and to draw their attention to aspects of their practice which they may be overlooking (either by judging themselves too harshly or too kindly). The purpose of this activity is to help the mentee identify areas for particular development in relation to Module 8 and also to recognise and celebrate areas of relative strength / confidence.
 
-1. Action Planning
+## Action Planning
 
 Agree with your mentee how you will use the outcomes from the audit to choose an area of focus for an exploratory practitioner inquiry, to run throughout the remainder of this module. At the start of Modules 6 and 7, you helped your mentee to devise an exploratory question. You will repeat that exercise now, to help frame the baseline for a longer practitioner inquiry.
 

--- a/content/ucl/year-2-inquiry-into-developing-quality-pedagogy-and-making-productive-use-of-assessment-part-2/spring-week-2-ect-self-study-activities.md
+++ b/content/ucl/year-2-inquiry-into-developing-quality-pedagogy-and-making-productive-use-of-assessment-part-2/spring-week-2-ect-self-study-activities.md
@@ -19,14 +19,11 @@ Read the case studies on this week’s topic, or the one that is most relevant t
 Take a few minutes to plan how you will use your self-directed study time this week. Think about:
 
 - what evidence you already have for the way you teach now, and the impact it has on your pupils, e.g.
-
   - your module audit
   - observation notes from last week
   - the work your pupils are producing
   - what your pupils are saying in class, how they are responding to feedback
-
 - what evidence it would still be useful for you to collect, e.g.
-
   - the views of your pupils about this change in your practice – how has it altered their attitudes to learning?
   - how the responses of your pupils to the change in your teaching may have altered over time – some may have started well but begun to level off. Can you track that?
   - how the change in your practice is affecting different pupils in different ways

--- a/content/ucl/year-2-inquiry-into-developing-quality-pedagogy-and-making-productive-use-of-assessment-part-2/spring-week-3-mentor-materials.md
+++ b/content/ucl/year-2-inquiry-into-developing-quality-pedagogy-and-making-productive-use-of-assessment-part-2/spring-week-3-mentor-materials.md
@@ -68,9 +68,8 @@ Louise:
 
 Through experimenting with ‘minimal marking’ as an alternative to always giving full written feedback, she learned better how to reduce the opportunity cost of marking by using codes and verbal feedback (6p). She also learned better how to give whole-class feedback so they knew what they needed to do to improve, and had the time to do it. (6h) Her claims therefore are:
 
-1\.\_ \_Using codes/verbal feedback does not detrimentally affect pupil progress, compared with a standard written marking approach.
-
-2\. On average, using codes/verbal feedback saves the teacher 30-45 minutes a week, per teaching class, compared with a standard written marking approach.
+1. Using codes/verbal feedback does not detrimentally affect pupil progress, compared with a standard written marking approach.
+2. On average, using codes/verbal feedback saves the teacher 30-45 minutes a week, per teaching class, compared with a standard written marking approach.
 
 She will use this insight to now apply the same principles of verbal feedback and minimal marking to her Year 7 and Year 8 classes, while monitoring the impact of that on her pupils and herself.
 

--- a/content/ucl/year-2-inquiry-into-engaging-pupils-in-learning/autumn-week-4-mentor-materials.md
+++ b/content/ucl/year-2-inquiry-into-engaging-pupils-in-learning/autumn-week-4-mentor-materials.md
@@ -116,12 +116,10 @@ Throughout the session, try to refer explicitly to the Learning Intentions and e
 Review 5 mins
 
 1. Start this session by briefly following up the actions that the mentee set at the end of last week’s mentor meeting. Ask your mentee to summarise
-
-- what they did
-- the impact of this on pupil learning (including how they are evaluating this)
-- what they will do going forward to build on these actions
-
-(2) Clarify the Learning Intentions for this session with your mentee
+  - what they did
+  - the impact of this on pupil learning (including how they are evaluating this)
+  - what they will do going forward to build on these actions
+2. Clarify the Learning Intentions for this session with your mentee
 
 Plan and Theory to Practice 40 mins
 


### PR DESCRIPTION
Some of the lists had blank lines in them which, in Markdown, causes a new list be rendered which isn't semantically correct, and numbering will restart at 1, which is confusing.

There are some other minor reformatting and removal of `<p>` tags etc here too as they appeared in/around the lists I was targetting.
