### PR TITLE
Simplify headings

### DIFF
--- a/content/education-development-trust.md
+++ b/content/education-development-trust.md
@@ -4,60 +4,60 @@ title: "Education Development Trust"
 
 ## Year 1: Autumn term
 
-### [First half-term: establishing a positive climate for learning](/education-development-trust/year-1-establishing-a-positive-climate-for-learning)
+### [Establishing a positive climate for learning](/education-development-trust/year-1-establishing-a-positive-climate-for-learning)
 
 In this module you'll learn about teaching your pupils how to behave in your classroom, setting clear expectations and reinforcing these with consistent routines.
 
-### [Second half-term: how pupils learn](/education-development-trust/year-1-how-pupils-learn)
+### [How pupils learn](/education-development-trust/year-1-how-pupils-learn)
 
 In this module you'll gain an understanding of how the brain works, and how you can then design more effective learning for your pupils.
 
 ## Year 1: Spring term
 
-### [First half-term: developing effective classroom practice](/education-development-trust/year-1-developing-effective-classroom-practice)
+### [Developing effective classroom practice](/education-development-trust/year-1-developing-effective-classroom-practice)
 
 In this module you'll focus on the fundamental techniques you can use to become a more effective teacher.
 
-### [Second half-term: the importance of subject and curriculum knowledge](/education-development-trust/year-1-the-importance-of-subject-and-curriculum-knowledge)
+### [The importance of subject and curriculum knowledge](/education-development-trust/year-1-the-importance-of-subject-and-curriculum-knowledge)
 
 In this module you'll learn practical ways to develop your subject and curriculum knowledge.
 
 ## Year 1: Summer term
 
-### [First half-term: assessment, feedback and questioning](/education-development-trust/year-1-assessment-feedback-and-questioning)
+### [Assessment, feedback and questioning](/education-development-trust/year-1-assessment-feedback-and-questioning)
 
 In this module you'll work on developing effective assessment and feedback practices.
 
-### [Second half-term: a people profession](/education-development-trust/year-1-a-people-profession)
+### [A people profession](/education-development-trust/year-1-a-people-profession)
 
 In this module you'll focus on developing strong professional relationships to build the best outcomes for your pupils.
 
 ## Year 2: Autumn term
 
-### [First half-term: embedding a positive climate for learning](/education-development-trust/year-2-embedding-a-positive-climate-for-learning)
+### [Embedding a positive climate for learning](/education-development-trust/year-2-embedding-a-positive-climate-for-learning)
 
 In this module you'll look at what motivates pupils so you can develop a really purposeful learning environment.
 
-### [Second half-term: how pupils learn - making it stick](/education-development-trust/year-2-how-pupils-learn-making-it-stick)
+### [How pupils learn - making it stick](/education-development-trust/year-2-how-pupils-learn-making-it-stick)
 
 In this module you'll consider how you can make new learning stick over time so that pupils remember what they've been taught.
 
 ## Year 2: Spring term
 
-### [First half-term: enhancing classroom practice - grouping and tailoring](/education-development-trust/year-2-enhancing-classroom-practice-grouping-and-tailoring)
+### [Enhancing classroom practice - grouping and tailoring](/education-development-trust/year-2-enhancing-classroom-practice-grouping-and-tailoring)
 
 In this module you'll enhance your teaching effectiveness by learning advanced group and pair working skills.
 
-### [Second half-term: revisiting the importance of subject and curriculum knowledge](/education-development-trust/year-2-revisiting-the-importance-of-subject-and-curriculum-knowledge)
+### [Revisiting the importance of subject and curriculum knowledge](/education-development-trust/year-2-revisiting-the-importance-of-subject-and-curriculum-knowledge)
 
 In this module you'll focus on how you can use your in-depth understanding of the subjects you teach to strengthen your pupils' knowledge.
 
 ## Year 2: Summer term
 
-### [First half-term: deepening assessment, feedback and questioning](/education-development-trust/year-2-deepening-assessment-feedback-and-questioning)
+### [Deepening assessment, feedback and questioning](/education-development-trust/year-2-deepening-assessment-feedback-and-questioning)
 
 In this module you'll build on your existing knowledge to develop further practical ways to hone your assessment, feedback and questioning techniques.
 
-### [Second half-term: continuing your professional development](/education-development-trust/year-2-continuing-your-professional-development)
+### [Continuing your professional development](/education-development-trust/year-2-continuing-your-professional-development)
 
 In the final module you will learn how professional development can help you improve your practice.

--- a/content/teach-first.md
+++ b/content/teach-first.md
@@ -4,30 +4,30 @@ title: "Teach First"
 
 ## Year 1: Autumn term
 
-### [First half-term: how can you create an effective learning environment?](/teach-first/year-1-how-can-you-create-an-effective-learning-environment)
+### [How can you create an effective learning environment?](/teach-first/year-1-how-can-you-create-an-effective-learning-environment)
 
 In this module you'll explore what effective learning environments look like and strategies you can use to achieve them.
 
-### [Second half-term: how do pupils learn?](/teach-first/year-1-how-do-pupils-learn)
+### [How do pupils learn?](/teach-first/year-1-how-do-pupils-learn)
 
 In this module you'll explore the findings and evidence gathered during studies of how pupils learn, and the related implications for teaching.
 
 ## Year 1: Spring term
 
-### [First half-term: what makes classroom practice effective?](/teach-first/year-1-what-makes-classroom-practice-effective)
+### [What makes classroom practice effective?](/teach-first/year-1-what-makes-classroom-practice-effective)
 
 In this module you'll hear an education expert talking about the features of effective classroom practice and why they are so important. You'll then explore the features in detail and have time to plan them into your sequences of lessons.
 
-### [Second half-term: how can you use assessment and feedback to greatest effect?](/teach-first/year-1-how-can-you-use-assessment-and-feedback-to-greatest-effect)
+### [How can you use assessment and feedback to greatest effect?](/teach-first/year-1-how-can-you-use-assessment-and-feedback-to-greatest-effect)
 
 In this module you'll hear from education experts about why assessment should be at the heart of your teaching. You'll also explore ways to give purposeful feedback to your pupils and what you can learn from summative data sets.
 
 ## Year 1: Summer term
 
-### [First half-term: how can you support all pupils to succeed?](/teach-first/year-1-how-can-you-support-all-pupils-to-succeed)
+### [How can you support all pupils to succeed?](/teach-first/year-1-how-can-you-support-all-pupils-to-succeed)
 
 In this module you'll hear a variety of educational specialists talk about ways to support all pupils to succeed across the curriculum, and why this is so important.
 
-### [Second half-term: how to design a coherent curriculum](/teach-first/year-1-how-to-design-a-coherent-curriculum)
+### [How to design a coherent curriculum](/teach-first/year-1-how-to-design-a-coherent-curriculum)
 
 In this module you'll learn how to design a carefully sequenced and coherent scheme of work, and how this will improve learning for your pupils.

--- a/content/ucl.md
+++ b/content/ucl.md
@@ -4,63 +4,63 @@ title: "UCL"
 
 ## Year 1: Autumn term
 
-### [First half-term: enabling pupil learning](/ucl/year-1-enabling-pupil-learning)
+### [Enabling pupil learning](/ucl/year-1-enabling-pupil-learning)
 
 In this module you'll focus on how you set up your classroom as a learning environment.
 
 You'll be able to reflect on the different ways you can influence your environment, and learn practical strategies that keep pupils safe, motivated and focused on learning.
 
-### [Second half-term: engaging pupils in learning](/ucl/year-1-engaging-pupils-in-learning)
+### [Engaging pupils in learning](/ucl/year-1-engaging-pupils-in-learning)
 
 In this module you'll look at the impact of pupils’ prior knowledge on their learning and how knowledge changes through the cooperation of working and long-term memory.
 
 ## Year 1: Spring term
 
-### [First half term: developing quality pedagogy (part 1)](/ucl/year-1-first-half-term-developing-quality-pedagogy-part-1)
+### [Developing quality pedagogy (part 1)](/ucl/year-1-first-half-term-developing-quality-pedagogy-part-1)
 
 In this module you'll extend your knowledge of effective modelling that enables pupils to tackle difficult concepts.
 
-### [Second half term: developing quality pedagogy (part 2)](/ucl/year-1-second-half-term-developing-quality-pedagogy-part-2)
+### [Developing quality pedagogy (part 2)](/ucl/year-1-second-half-term-developing-quality-pedagogy-part-2)
 
 In this module you'll extend your knowledge of effective modelling that enables pupils to tackle difficult concepts.
 
 ## Year 1: Summer term
 
-### [First half-term: making productive use of assessment](/ucl/year-1-making-productive-use-of-assessment)
+### [Making productive use of assessment](/ucl/year-1-making-productive-use-of-assessment)
 
 In this module you'll build on your existing knowledge of assessment principles.
 
-### [Second half-term: fulfilling professional responsibilities](/ucl/year-1-fulfilling-professional-responsibilities)
+### [Fulfilling professional responsibilities](/ucl/year-1-fulfilling-professional-responsibilities)
 
 In this module you'll consider what it means to be professional, and approaches to managing your professional development.
 
 ## Year 2: Autumn term
 
-### [First half-term: inquiry into enabling pupil learning](/ucl/year-2-inquiry-into-enabling-pupil-learning)
+### [Inquiry into enabling pupil learning](/ucl/year-2-inquiry-into-enabling-pupil-learning)
 
 In this module you'll focus on one particular part of your teaching to evaluate the impact your practices have on your pupils.
 
-### [Second half-term: inquiry into engaging pupils in learning](/ucl/year-2-inquiry-into-engaging-pupils-in-learning)
+### [Inquiry into engaging pupils in learning](/ucl/year-2-inquiry-into-engaging-pupils-in-learning)
 
 In this module you'll focus on how to improve your teaching without adding to your workload.
 
 ## Year 2: Spring term
 
-### [First half-term: inquiry into developing quality pedagogy and making productive use of assessment (part 1)](/ucl/year-2-inquiry-into-developing-quality-pedagogy-and-making-productive-use-of-assessment-part-1)
+### [Inquiry into developing quality pedagogy and making productive use of assessment (part 1)](/ucl/year-2-inquiry-into-developing-quality-pedagogy-and-making-productive-use-of-assessment-part-1)
 
 In this module you'll look at how to gather evidence about the impact your teaching is having, followed by practical tips on altering your practices to get better results.
 
-### [Second half-term: inquiry into developing quality pedagogy and making productive use of assessment (part 2)](/ucl/year-2-inquiry-into-developing-quality-pedagogy-and-making-productive-use-of-assessment-part-2)
+### [Inquiry into developing quality pedagogy and making productive use of assessment (part 2)](/ucl/year-2-inquiry-into-developing-quality-pedagogy-and-making-productive-use-of-assessment-part-2)
 
 In this module you'll look at how to gather evidence about the impact your teaching is having, followed by practical tips on altering your practices to get better results.
 
 ## Year 2: Summer term
 
-### [First half-term: inquiry into developing quality pedagogy and making productive use of assessment (part 3)](/ucl/year-2-inquiry-into-developing-quality-pedagogy-and-making-productive-use-of-assessment-part-3)
+### [Inquiry into developing quality pedagogy and making productive use of assessment (part 3)](/ucl/year-2-inquiry-into-developing-quality-pedagogy-and-making-productive-use-of-assessment-part-3)
 
 In this module you'll look at how to gather evidence about the impact your teaching is having, followed by practical tips on altering your practices to get better results.
 
-### [Second half-term: fulfilling professional responsibilities](/ucl/year-2-fulfilling-professional-responsibilities)
+### [Fulfilling professional responsibilities](/ucl/year-2-fulfilling-professional-responsibilities)
 
 The module revisits the content of module 5 from the first year of the programme.
 


### PR DESCRIPTION
Remove the repeated "First half-term" and "Second half-term" in order to shorten the headings and front-load the more important bits of information.

This also makes things more consistent too, as the Ambition materials already follow this format.