### PR TITLE
Fix breaking checks

### DIFF
--- a/.github/actions/build-site/action.yml
+++ b/.github/actions/build-site/action.yml
@@ -1,0 +1,25 @@
+name: Build site
+description: Builds the final HTML using Nanoc build
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true
+        cache-version: 0
+
+    - name: Setup Node
+      uses: actions/setup-node@v3
+      with:
+        node-version: 20
+        cache: npm
+
+    - name: Install dependencies
+      shell: bash
+      run: npm ci
+
+    - name: Build
+      shell: bash
+      run: bundle exec nanoc

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,20 @@
+name: Content checks
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+jobs:
+  run-nanoc-checks:
+    concurrency: ci-${{ github.ref }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Build site
+        uses: ./.github/actions/build-site
+
+      - name: Run Nanoc checks
+        run: make check

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,23 +16,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
-          cache-version: 0
-
-      - name: Setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 20
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build
-        run: bundle exec nanoc
+      - name: Build site
+        uses: ./.github/actions/build-site
 
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@v4

--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,6 @@ npm_install:
 
 bundle_install:
 	bundle install
+
+check:
+	bundle exec nanoc check

--- a/Rules
+++ b/Rules
@@ -18,6 +18,10 @@ compile '/**/*.md' do
   write item.identifier.without_ext + '/index.html'
 end
 
+compile '/assets/materials/**/*' do
+  write '/assets/materials/' + File.basename(item.identifier.to_s)
+end
+
 %w(woff woff2).each do |ext|
   compile("/**/*.#{ext}") do
     write '/assets/fonts/' + File.basename(item.identifier.to_s)

--- a/content/assets/images/favicon.ico
+++ b/content/assets/images/favicon.ico
@@ -1,0 +1,1 @@
+../../../node_modules/govuk-frontend/govuk/assets/images/favicon.ico

--- a/content/assets/images/govuk-mask-icon.svg
+++ b/content/assets/images/govuk-mask-icon.svg
@@ -1,0 +1,1 @@
+../../../node_modules/govuk-frontend/govuk/assets/images/govuk-mask-icon.svg

--- a/content/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-5-mentor-materials.md
+++ b/content/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-5-mentor-materials.md
@@ -22,9 +22,9 @@ In the online study materials, your teacher was asked to reflect on a time when 
 
 The case studies your teacher has read only included information on the pupil and the incident, not information on how the teacher responded to that behaviour but if you wish, you can see how the teacher did respond which can support your discussion with your teacher. The case studies, which include how the teacher responded, are included in further sections of this page:
 
-- [Early Years case study](/teach-first/year-1/autumn-1/topic-5/mentoring/1/part-3)
-- [Primary case study](/teach-first/year-1/autumn-1/topic-5/mentoring/1/part-4)
-- [Secondary case study](/teach-first/year-1/autumn-1/topic-5/mentoring/1/part-5)
+- [Early Years case study](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-5-mentor-materials#early-years-challenging-behaviour-case-study)
+- [Primary case study](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-5-mentor-materials#primary-challenging-behaviour-case-study)
+- [Secondary case study](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-5-mentor-materials#secondary-challenging-behaviour-case-study)
 
 ### Praise, probe and set precise actions
 

--- a/content/teach-first/year-1-how-to-design-a-coherent-curriculum/summer-week-5-ect-theory.md
+++ b/content/teach-first/year-1-how-to-design-a-coherent-curriculum/summer-week-5-ect-theory.md
@@ -10,9 +10,9 @@ next_path: "/teach-first/year-1-how-to-design-a-coherent-curriculum/summer-week-
 
 Take some time now to review the following content from module 3:
 
-- [Session 2: Explanations and modelling (up to and including explanations)](/teach-first/year-1/spring-1/topic-3/part-1)
-- [Session 3: Guided practice](/teach-first/year-1/spring-1/topic-4/part-1)
-- [Session 4: Independent practice](/teach-first/year-1/spring-1/topic-5/part-1)
+- [Session 2: Explanations and modelling (up to and including explanations)](/teach-first/year-1-what-makes-classroom-practice-effective#week-2-explanations-and-modelling)
+- [Session 3: Guided practice](/teach-first/year-1-what-makes-classroom-practice-effective#week-3-guided-practice)
+- [Session 4: Independent practice](/teach-first/year-1-what-makes-classroom-practice-effective#week-4-independent-practice)
 
 In these sessions you learnt about how to support pupils to gradually build pupils’ knowledge throughout a lesson, but the same principles apply to a learning objective that may need to extend over a series of lessons.
 

--- a/content/teach-first/year-2-first-half-term-developing-pupils-intrinsic-motivation.md
+++ b/content/teach-first/year-2-first-half-term-developing-pupils-intrinsic-motivation.md
@@ -16,8 +16,6 @@ Duration: 45 minutes.
 
 Retrieve the relevant year one materials so that you can refer to them in this module.
 
-[View mentor materials](/teach-first/year-2-first-half-term-developing-pupils-intrinsic-motivation/autumn-week-1-mentor-materials)
-
 ## Week 2 - Run mentor sessions
 
 There are no new ECT materials.
@@ -31,8 +29,6 @@ Run a 90-minute training session and a 60-minute discussion with ECTs about pupi
 - identify strategies to increase pupil motivation
 - reflect on their own teaching and areas for development
 
-[View mentor materials](/teach-first/year-2-first-half-term-developing-pupils-intrinsic-motivation/autumn-week-2-mentor-materials)
-
 ## Week 3 - Arrange an observation and follow-up discussion
 
 There are no new ECT materials.
@@ -42,8 +38,6 @@ Duration: 60 minutes.
 ### Mentors
 
 Arrange for your ECTs to observe an expert colleague and follow up with them to discuss how the teacher supported pupil learning.
-
-[View mentor materials](/teach-first/year-2-first-half-term-developing-pupils-intrinsic-motivation/autumn-week-3-mentor-materials)
 
 ## Weeks 3 to 5: Help ECTs integrate what they’ve learnt
 
@@ -55,8 +49,6 @@ Duration: minutes.
 
 Encourage ECTs to use what they’ve learnt in their own teaching.
 
-[View mentor materials](/teach-first/year-2-first-half-term-developing-pupils-intrinsic-motivation/autumn-week-0-mentor-materials)
-
 ## Weeks 5 to 6: Observe ECTs and give feedback
 
 There are no new ECT materials.
@@ -66,5 +58,3 @@ Duration: 80 minutes.
 ### Mentors
 
 Observe ECTs and give feedback.
-
-[View mentor materials](/teach-first/year-2-first-half-term-developing-pupils-intrinsic-motivation/autumn-week-0-mentor-materials)

--- a/nanoc.yaml
+++ b/nanoc.yaml
@@ -14,3 +14,9 @@ prune:
 data_sources:
   - type: filesystem
     encoding: utf-8
+
+checking:
+  enabled_checks:
+    - internal_links
+    - mixed_content
+    - stale


### PR DESCRIPTION
Get the [Nanoc checks](https://nanoc.app/doc/testing/) passing. The checks are:

* `css` - excluded, doesn't like some of the things done in govuk-frontend ❌ 
* `html` - excluded, hits W3C validator's rate limit ❌ 
* `external_links` - excluded, lots of failures due to link rot ❌ 
* `internal_links` included, now all passing ✅ 
* `stale` included, passing (makes sure non-Nanoc generated things are included in the `/output` directory) ✅ 
* `mixed_content` included, passing  (checks we're not linking to insecure resources) ✅ 

## Fixing things

- Add symlinks for govuk-mask-icon and favicon.ico
- Explicitly copy all materials files first
- Manually fix internal links

## Making the checks run automatically

- Add check step to Makefile
- Add check step that will run for each PR
