### PR TITLE
Add accessibility statement for site

### DIFF
--- a/content/accessibility.md
+++ b/content/accessibility.md
@@ -1,0 +1,153 @@
+---
+title: Accessibility
+---
+
+This statement applies to the Support for early career teachers service.
+
+This service is run by the Department for Education. We want as many people as possible to be able to use it. You should be able to:
+
+* change colours, contrast levels and fonts
+* zoom in up to 300% without the text spilling off the screen
+* navigate most of the service using just a keyboard
+* navigate most of the service using speech recognition software
+* listen to most of the service using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)
+
+We have also made the service text as simple as possible to understand.
+
+[AbilityNet](https://mcmw.abilitynet.org.uk/) has advice on making your device easier to use if you have an access need. 
+
+## How accessible this service is
+
+We know some parts of this website are not fully accessible. For example:
+
+* some tables may be used for layout purposes where other elements (like lists) should be used
+* some images are described twice, once in the alt text and once in the content
+* some images are used unnecessarily and can be removed
+* some headings may be incorrectly nested
+* some videos have auto-generated subtitles that may be inaccurate
+
+## Reporting accessibility problems with this service
+
+We are always looking to improve the accessibility of this service. If you find any problems not listed on this page or think we are not meeting accessibility requirements, contact us. Email [continuing-professional-development@digital.education.gov.uk](mailto:continuing-professional-development@digital.education.gov.uk)
+
+[Read tips on contacting organisations about inaccessible websites](http://www.w3.org/WAI/users/inaccessible).
+
+## Enforcement procedure
+
+The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’).
+
+If you are not happy with how we respond to your complaint, [contact the Equality Advisory and Support Service (EASS)](https://www.equalityadvisoryservice.com/).
+
+### Technical information about this service’s accessibility
+
+The Department for Education is committed to making this service accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No.2) Accessibility Regulations 2018.
+
+### Compliance status
+
+This service is partially compliant with the [Web Content Accessibility Guidelines version 2.1](https://www.w3.org/TR/WCAG21/) AA standard.
+
+### Non-accessible content
+
+The content listed below is non-accessible for the following reasons.
+
+### Non-compliance with the accessibility regulations
+
+We plan to fix most non-compliance issues by the end of December 2021:
+
+There may be other accessibility issues we have not found yet. If you find any please contact us so we can continue to improve the services we provide.
+
+### Disproportionate burden
+
+Not applicable.
+
+### Content not within scope of this accessibility statement
+
+Not applicable.
+
+### What we’re doing to improve accessibility
+
+We have used the government’s fully accessible pattern library, which is optimised for common user tasks, to build this service. This pattern library is built with keyboard accessibility, colour contrast, structural elements and error best practice.
+
+Parts of the website are not accessible. Training content has been designed and written by third parties. This content is often interactive, designed to be printed and uses elements not compatible with the GOV.UK design system.
+
+We have been working to fix accessibility issues related to use of tables, use of images, inconsistent use of headings and other structural tags. Due to the vast amounts of third-party content, we have not been able to fix all instances.
+
+### Tables used for layout or decorative purposes
+
+We have been:
+
+* reformatting tables as bulleted lists or sections with headers and paragraphs
+* adapting tables that have been designed for printing and being written in
+* deleting tables that then repeated content as non-table text
+
+The impact of presenting content as tables is that it may not make sense to screen reader users, screen magnification users or those that increase text size.
+
+### Images used to convey information lacking alt text
+
+There were instances of images of text, missing alt text descriptions of images and redundant image diagrams disconnected from context.
+
+We have been:
+
+* re-writing images of text as html
+* adding ‘alt text’ descriptions where images conveyed information so equivalent information is available
+* removing redundant images that added no value
+
+Incorrect use of images affects:
+
+* screen reader users, who will be unable to get equivalent information
+* screen magnification users who might see text pixelated
+* users who adapt the visual presentation of text. For example, users with dyslexia who might use a different font and background colour will not get their optimal text styling
+
+### Inconsistent use of the heading ‘h’ tags
+
+We fixed multiple instances of incorrect use of heading tags.
+
+We have been:
+
+* correcting the incorrect nesting of headings, so that heading levels are correct
+* re-writing whole sentences that were used as headings
+
+### Incorrect use of headings affects:
+
+* screen reader users who are prevented from understanding the structure of a page and skip to the right part of it
+* users who scan-read the page
+
+### Use of structural elements for presentational purposes
+
+Bolding has been used to highlight words arbitrarily, diverging from the GOV.UK style guide. We have unbolded elements and applied correct emphasis tags.
+Videos
+
+We have fixed videos playing automatically when users first enter the page.
+
+We have not been able to address auto-generated subtitles in third party videos.
+
+Pre-recorded audio and video published before 23 September 2020 is exempt from the accessibility regulations.
+Automated testing
+
+We use automated testing to find and fix common accessibility issues like poor form labelling. Specifically, we use the Cypress testing tool to run the tests and a package called Axe-core to run checks in the Cypress environment.
+
+### Manual evaluation
+
+We have fixed videos playing automatically when users first enter the page.
+
+We manually inspected a representative sample of pages and identified accessibility issues using a manual inspection using the [SCULPT method](https://www.worcestershire.gov.uk/sculpt").
+
+We have fixed videos playing automatically when users first enter the page.
+
+We then prioritised issues based on the impact on user experience and feasibility to fix within the time available.
+
+### Preparation of this accessibility statement
+
+This statement was prepared on 3 August 2021.
+
+The service was last tested on 25 August 2021 for compliance with WCAG 2.1 AA.
+
+Testing was carried out internally by the Department for Education.
+
+We tested the service based on a user’s ability to complete key journeys.
+
+All parts of the chosen journeys were tested.
+
+Journeys were chosen on a number of factors, including risk assessments and subject matter.
+
+We will have an external accessibility audit carried out by the end of December 2021.

--- a/layouts/partials/footer.slim
+++ b/layouts/partials/footer.slim
@@ -6,6 +6,8 @@ footer.govuk-footer role='contentinfo'
         ul.govuk-footer__inline-list
           li.govuk-footer__inline-list-item
             == link_to("Accessibility", "/accessibility", class: "govuk-footer__link")
+          li.govuk-footer__inline-list-item
+            == link_to("Privacy", "https://www.gov.uk/government/organisations/department-for-education/about/personal-information-charter", class: "govuk-footer__link")
 
         svg.govuk-footer__licence-logo[
           role="presentation"

--- a/layouts/partials/footer.slim
+++ b/layouts/partials/footer.slim
@@ -2,6 +2,10 @@ footer.govuk-footer role='contentinfo'
   .govuk-width-container
     .govuk-footer__meta
       .govuk-footer__meta-item.govuk-footer__meta-item--grow
+        h2.govuk-visually-hidden Support links
+        ul.govuk-footer__inline-list
+          li.govuk-footer__inline-list-item
+            == link_to("Accessibility", "/accessibility", class: "govuk-footer__link")
 
         svg.govuk-footer__licence-logo[
           role="presentation"


### PR DESCRIPTION
Add an accessibility statement for the app. It was copied from the legacy site.

Also add a link to the DfE's [new privacy page](https://www.gov.uk/government/organisations/department-for-education/about/personal-information-charter).
