### PR TITLE
Allow cookie toggling from `/cookies` page

### DIFF
--- a/content/assets/css/application.scss
+++ b/content/assets/css/application.scss
@@ -298,3 +298,7 @@ main {
 .hidden-unless-js-enabled {
   display: none;
 }
+
+.hidden {
+  display: none;
+}

--- a/content/assets/javascript/analytics.js
+++ b/content/assets/javascript/analytics.js
@@ -1,29 +1,65 @@
+// configuring cookies on initial visit
+
 const cookieBanner = document.getElementById("cookie-banner");
 const cookieHiddenClass = "hidden-unless-js-enabled";
 const cookieKey = "cookies_accepted";
 
 const showCookieBanner = () => { cookieBanner.classList.remove(cookieHiddenClass); }
 const hideCookieBanner = () => { cookieBanner.classList.add(cookieHiddenClass); }
+const reloadPage = () => { window.location.reload(); }
 const acceptCookies = () => { localStorage.setItem(cookieKey, "yes") }
 const rejectCookies = () => { localStorage.setItem(cookieKey, "no") }
 
 const acceptButton = document.querySelector("#accept-cookies");
 const rejectButton = document.querySelector("#reject-cookies");
 
+// toggling cookies once set
+
+const enableButton = document.querySelector("#enable-cookies");
+const disableButton = document.querySelector("#disable-cookies");
+
+const cookiesEnabled = localStorage.getItem(cookieKey) == "yes";
+
+// only show cookie control if JavaScript is enabled, as it's required
+// to toggle it
+if (cookiesEnabled) {
+  const cookieControlDisableControl = document.getElementById("cookie-control-enabled");
+
+  cookieControlDisableControl.classList.remove("hidden");
+} else {
+  const cookieControlEnableControl = document.getElementById("cookie-control-disabled");
+
+  cookieControlEnableControl.classList.remove("hidden");
+}
+
 document.addEventListener("DOMContentLoaded", () => {
   // if there's any response to the cookie banner, leave it hidden,
   // otherwise show it and add handlers for the accept/reject clicks
   if (!localStorage.getItem("cookies_accepted")) {
     showCookieBanner();
-
-    acceptButton.addEventListener("click", () => {
-      acceptCookies();
-      hideCookieBanner();
-    });
-
-    rejectButton.addEventListener("click", () => {
-      rejectCookies();
-      hideCookieBanner();
-    });
   }
+
+  acceptButton.addEventListener("click", () => {
+    acceptCookies();
+
+    hideCookieBanner();
+  });
+
+  rejectButton.addEventListener("click", () => {
+    rejectCookies();
+
+    hideCookieBanner();
+  });
+
+  enableButton.addEventListener("click", () => {
+    acceptCookies();
+
+    reloadPage();
+  });
+
+  disableButton.addEventListener("click", () => {
+    rejectCookies();
+
+    reloadPage();
+  });
 });

--- a/content/cookies.md
+++ b/content/cookies.md
@@ -42,3 +42,23 @@ Google Analytics stores anonymised information about:
     </tr>
   </tbody>
 </table>
+
+<div id="cookie-control-disabled" class="hidden">
+  <h2 class="govuk-heading-m">Cookie settings</h2>
+
+  <p>Analytics cookies are <strong>disabled</strong>.</p>
+
+  <button id="enable-cookies" class="govuk-button" data-module="govuk-button">
+    Enable analytics cookies
+  </button>
+</div>
+
+<div id="cookie-control-enabled" class="hidden">
+  <h2 class="govuk-heading-m">Cookie settings</h2>
+
+  <p>Analytics cookies are <strong>enabled</strong>.</p>
+
+  <button id="disable-cookies" class="govuk-button" data-module="govuk-button">
+    Disable analytics cookies
+  </button>
+</div>

--- a/layouts/partials/footer.slim
+++ b/layouts/partials/footer.slim
@@ -8,6 +8,8 @@ footer.govuk-footer role='contentinfo'
             == link_to("Accessibility", "/accessibility", class: "govuk-footer__link")
           li.govuk-footer__inline-list-item
             == link_to("Privacy", "https://www.gov.uk/government/organisations/department-for-education/about/personal-information-charter", class: "govuk-footer__link")
+          li.govuk-footer__inline-list-item
+            == link_to("Cookies", "/cookies", class: "govuk-footer__link")
 
         svg.govuk-footer__licence-logo[
           role="presentation"


### PR DESCRIPTION
We allowed setting the cookies via the banner but not subsequently.

Now it's toggleable from the cookies page.

| Add cookies link to footer | Enable cookies when disabled | Disable cookies when enabled |
| -------------------------- | -------------------------| ----------------------------|
|  ![Screenshot from 2024-04-02 11-28-46](https://github.com/DFE-Digital/support-for-early-career-teachers/assets/128088/0f8085a5-5957-4cf7-8805-642c97f6d44d) |![Screenshot from 2024-04-02 11-28-51](https://github.com/DFE-Digital/support-for-early-career-teachers/assets/128088/4cb1816f-1bc2-4c85-b60f-c06ec00e9fbf) |![Screenshot from 2024-04-02 11-28-55](https://github.com/DFE-Digital/support-for-early-career-teachers/assets/128088/31e73c35-7742-4f5a-a3e3-de863f51f665) |