### PR TITLE
[CST-2661] Accessibility link purpose

### DIFF
--- a/content/ambition-institute/year-1-behaviour.md
+++ b/content/ambition-institute/year-1-behaviour.md
@@ -27,13 +27,13 @@ Duration: 40 minutes.
 
 1. [Video and module introduction](/ambition-institute/year-1-behaviour/autumn-week-1-ect-video-and-module-introduction)
 2. [Module overview](/ambition-institute/year-1-behaviour/autumn-week-1-ect-module-overview)
-3. [Reflect](/ambition-institute/year-1-behaviour/autumn-week-1-ect-reflect)
+3. [Reflect](/ambition-institute/year-1-behaviour/autumn-week-1-ect-reflect 'Reflect week 1')
 
 ### Mentors
 
 Introduces foundational elements of behaviour and supports teachers and mentors to set up effective ways of working.
 
-[View mentor materials](/ambition-institute/year-1-behaviour/autumn-week-1-mentor-materials)
+[View mentor materials](/ambition-institute/year-1-behaviour/autumn-week-1-mentor-materials 'View mentor materials week 1')
 
 ## Week 2: routines
 
@@ -41,15 +41,15 @@ Explores effective routines, the role of classroom environment and its connectio
 
 Duration: 40 minutes.
 
-1. [Video](/ambition-institute/year-1-behaviour/autumn-week-2-ect-video)
-2. [Teaching challenge](/ambition-institute/year-1-behaviour/autumn-week-2-ect-teaching-challenge)
-3. [Reflect](/ambition-institute/year-1-behaviour/autumn-week-2-ect-reflect)
+1. [Video](/ambition-institute/year-1-behaviour/autumn-week-2-ect-video 'Video week 2')
+2. [Teaching challenge](/ambition-institute/year-1-behaviour/autumn-week-2-ect-teaching-challenge 'Teaching challenge week 2')
+3. [Reflect](/ambition-institute/year-1-behaviour/autumn-week-2-ect-reflect 'Reflect week 2')
 
 ### Mentors
 
 Explores effective routines, the role of classroom environment and its connection to learning.
 
-[View mentor materials](/ambition-institute/year-1-behaviour/autumn-week-2-mentor-materials)
+[View mentor materials](/ambition-institute/year-1-behaviour/autumn-week-2-mentor-materials 'View mentor materials week 2')
 
 ## Week 3: instructions
 
@@ -57,15 +57,15 @@ Shares role of high-quality instructions and how to plan and reinforce them.
 
 Duration: 40 minutes.
 
-1. [Video](/ambition-institute/year-1-behaviour/autumn-week-3-ect-video)
-2. [Teaching challenge](/ambition-institute/year-1-behaviour/autumn-week-3-ect-teaching-challenge)
-3. [Reflect](/ambition-institute/year-1-behaviour/autumn-week-3-ect-reflect)
+1. [Video](/ambition-institute/year-1-behaviour/autumn-week-3-ect-video 'Video week 3')
+2. [Teaching challenge](/ambition-institute/year-1-behaviour/autumn-week-3-ect-teaching-challenge 'Teaching challenge week 3')
+3. [Reflect](/ambition-institute/year-1-behaviour/autumn-week-3-ect-reflect 'Reflect week 3')
 
 ### Mentors
 
 Shares role of high-quality instructions and how to plan and reinforce them.
 
-[View mentor materials](/ambition-institute/year-1-behaviour/autumn-week-3-mentor-materials)
+[View mentor materials](/ambition-institute/year-1-behaviour/autumn-week-3-mentor-materials 'View mentor materials week 3')
 
 ## Week 4: directing attention
 
@@ -73,15 +73,15 @@ Examines monitoring and reinforcing expectations with praise, voice and movement
 
 Duration: 40 minutes.
 
-1. [Video](/ambition-institute/year-1-behaviour/autumn-week-4-ect-video)
-2. [Teaching challenge](/ambition-institute/year-1-behaviour/autumn-week-4-ect-teaching-challenge)
-3. [Reflect](/ambition-institute/year-1-behaviour/autumn-week-4-ect-reflect)
+1. [Video](/ambition-institute/year-1-behaviour/autumn-week-4-ect-video 'Video week 4')
+2. [Teaching challenge](/ambition-institute/year-1-behaviour/autumn-week-4-ect-teaching-challenge 'Teaching challenge week 4')
+3. [Reflect](/ambition-institute/year-1-behaviour/autumn-week-4-ect-reflect 'Reflect week 4')
 
 ### Mentors
 
 Examines monitoring and reinforcing expectations with praise, voice and movement(s).
 
-[View mentor materials](/ambition-institute/year-1-behaviour/autumn-week-4-mentor-materials)
+[View mentor materials](/ambition-institute/year-1-behaviour/autumn-week-4-mentor-materials 'View mentor materials week 4')
 
 ## Week 5: low-level disruption
 
@@ -89,15 +89,15 @@ Focuses on managing low-level disruption to learning and how to maintain a posit
 
 Duration: 40 minutes.
 
-1. [Video](/ambition-institute/year-1-behaviour/autumn-week-5-ect-video)
-2. [Teaching challenge](/ambition-institute/year-1-behaviour/autumn-week-5-ect-teaching-challenge)
-3. [Reflect](/ambition-institute/year-1-behaviour/autumn-week-5-ect-reflect)
+1. [Video](/ambition-institute/year-1-behaviour/autumn-week-5-ect-video 'Video week 5')
+2. [Teaching challenge](/ambition-institute/year-1-behaviour/autumn-week-5-ect-teaching-challenge 'Teaching challenge week 5')
+3. [Reflect](/ambition-institute/year-1-behaviour/autumn-week-5-ect-reflect 'Reflect week 5')
 
 ### Mentors
 
 Focuses on managing low-level disruption to learning and how to maintain a positive environment.
 
-[View mentor materials](/ambition-institute/year-1-behaviour/autumn-week-5-mentor-materials)
+[View mentor materials](/ambition-institute/year-1-behaviour/autumn-week-5-mentor-materials 'View mentor materials week 5')
 
 ## Week 6: consistency
 
@@ -105,15 +105,15 @@ Explores how teacher consistency builds a positive learning environment.
 
 Duration: 40 minutes.
 
-1. [Video](/ambition-institute/year-1-behaviour/autumn-week-6-ect-video)
-2. [Teaching challenge](/ambition-institute/year-1-behaviour/autumn-week-6-ect-teaching-challenge)
-3. [Reflect](/ambition-institute/year-1-behaviour/autumn-week-6-ect-reflect)
+1. [Video](/ambition-institute/year-1-behaviour/autumn-week-6-ect-video 'Video week 6')
+2. [Teaching challenge](/ambition-institute/year-1-behaviour/autumn-week-6-ect-teaching-challenge 'Teaching challenge week 6')
+3. [Reflect](/ambition-institute/year-1-behaviour/autumn-week-6-ect-reflect 'Reflect week 6')
 
 ### Mentors
 
 Explores how teacher consistency builds a positive learning environment.
 
-[View mentor materials](/ambition-institute/year-1-behaviour/autumn-week-6-mentor-materials)
+[View mentor materials](/ambition-institute/year-1-behaviour/autumn-week-6-mentor-materials 'View mentor materials week 6')
 
 ## Week 7: positive learning environment
 
@@ -121,15 +121,15 @@ Focuses on the classroom culture required for pupils to learn effectively.
 
 Duration: 40 minutes.
 
-1. [Video](/ambition-institute/year-1-behaviour/autumn-week-7-ect-video)
-2. [Teaching challenge](/ambition-institute/year-1-behaviour/autumn-week-7-ect-teaching-challenge)
-3. [Reflect](/ambition-institute/year-1-behaviour/autumn-week-7-ect-reflect)
+1. [Video](/ambition-institute/year-1-behaviour/autumn-week-7-ect-video 'Video week 7')
+2. [Teaching challenge](/ambition-institute/year-1-behaviour/autumn-week-7-ect-teaching-challenge 'Teaching challenge week 7')
+3. [Reflect](/ambition-institute/year-1-behaviour/autumn-week-7-ect-reflect 'Reflect week 7')
 
 ### Mentors
 
 Focuses on the classroom culture required for pupils to learn effectively.
 
-[View mentor materials](/ambition-institute/year-1-behaviour/autumn-week-7-mentor-materials)
+[View mentor materials](/ambition-institute/year-1-behaviour/autumn-week-7-mentor-materials 'View mentor materials week 7')
 
 ## Week 8: structured support of learning
 
@@ -137,15 +137,15 @@ Shares the link between success, behaviour and breaking things up into small ste
 
 Duration: 40 minutes.
 
-1. [Video](/ambition-institute/year-1-behaviour/autumn-week-8-ect-video)
-2. [Teaching challenge](/ambition-institute/year-1-behaviour/autumn-week-8-ect-teaching-challenge)
-3. [Reflect](/ambition-institute/year-1-behaviour/autumn-week-8-ect-reflect)
+1. [Video](/ambition-institute/year-1-behaviour/autumn-week-8-ect-video 'Video week 8')
+2. [Teaching challenge](/ambition-institute/year-1-behaviour/autumn-week-8-ect-teaching-challenge 'Teaching challenge week 8')
+3. [Reflect](/ambition-institute/year-1-behaviour/autumn-week-8-ect-reflect 'Reflect week 8')
 
 ### Mentors
 
 Shares the link between success, behaviour and breaking things up into small steps.
 
-[View mentor materials](/ambition-institute/year-1-behaviour/autumn-week-8-mentor-materials)
+[View mentor materials](/ambition-institute/year-1-behaviour/autumn-week-8-mentor-materials 'View mentor materials week 8')
 
 ## Week 9: challenge
 
@@ -153,15 +153,15 @@ Explores the role challenge plays in pupil behaviour.
 
 Duration: 40 minutes.
 
-1. [Video](/ambition-institute/year-1-behaviour/autumn-week-9-ect-video)
-2. [Teaching challenge](/ambition-institute/year-1-behaviour/autumn-week-9-ect-teaching-challenge)
-3. [Reflect](/ambition-institute/year-1-behaviour/autumn-week-9-ect-reflect)
+1. [Video](/ambition-institute/year-1-behaviour/autumn-week-9-ect-video 'Video week 9')
+2. [Teaching challenge](/ambition-institute/year-1-behaviour/autumn-week-9-ect-teaching-challenge 'Teaching challenge week 9')
+3. [Reflect](/ambition-institute/year-1-behaviour/autumn-week-9-ect-reflect 'Reflect week 9')
 
 ### Mentors
 
 Explores the role challenge plays in pupil behaviour.
 
-[View mentor materials](/ambition-institute/year-1-behaviour/autumn-week-9-mentor-materials)
+[View mentor materials](/ambition-institute/year-1-behaviour/autumn-week-9-mentor-materials 'View mentor materials week 9')
 
 ## Week 10: independent practice
 
@@ -169,15 +169,15 @@ Considers the link between successful independent practice and expectations, rou
 
 Duration: 40 minutes.
 
-1. [Video](/ambition-institute/year-1-behaviour/autumn-week-10-ect-video)
-2. [Teaching challenge](/ambition-institute/year-1-behaviour/autumn-week-10-ect-teaching-challenge)
-3. [Reflect](/ambition-institute/year-1-behaviour/autumn-week-10-ect-reflect)
+1. [Video](/ambition-institute/year-1-behaviour/autumn-week-10-ect-video 'Video week 10')
+2. [Teaching challenge](/ambition-institute/year-1-behaviour/autumn-week-10-ect-teaching-challenge 'Teaching challenge week 10')
+3. [Reflect](/ambition-institute/year-1-behaviour/autumn-week-10-ect-reflect 'Reflect week 10')
 
 ### Mentors
 
 Considers the link between successful independent practice and expectations, routines and feedback.
 
-[View mentor materials](/ambition-institute/year-1-behaviour/autumn-week-10-mentor-materials)
+[View mentor materials](/ambition-institute/year-1-behaviour/autumn-week-10-mentor-materials 'View mentor materials week 10')
 
 ## Week 11: pairs and groups
 
@@ -185,15 +185,15 @@ Focuses on how to make paired and group work successful through expectations, ro
 
 Duration: 40 minutes.
 
-1. [Video](/ambition-institute/year-1-behaviour/autumn-week-11-ect-video)
-2. [Teaching challenge](/ambition-institute/year-1-behaviour/autumn-week-11-ect-teaching-challenge)
-3. [Reflect](/ambition-institute/year-1-behaviour/autumn-week-11-ect-reflect)
+1. [Video](/ambition-institute/year-1-behaviour/autumn-week-11-ect-video 'Video week 11')
+2. [Teaching challenge](/ambition-institute/year-1-behaviour/autumn-week-11-ect-teaching-challenge 'Teaching challenge week 11')
+3. [Reflect](/ambition-institute/year-1-behaviour/autumn-week-11-ect-reflect 'Reflect week 11')
 
 ### Mentors
 
 Focuses on how to make paired and group work successful through expectations, routines and culture.
 
-[View mentor materials](/ambition-institute/year-1-behaviour/autumn-week-11-mentor-materials)
+[View mentor materials](/ambition-institute/year-1-behaviour/autumn-week-11-mentor-materials 'View mentor materials week 11')
 
 ## Week 12: upholding high expectations
 
@@ -201,12 +201,12 @@ Looks at how teachers can uphold high expectations by ensuring pupils are suppor
 
 Duration: 40 minutes.
 
-1. [Video](/ambition-institute/year-1-behaviour/autumn-week-12-ect-video)
-2. [Teaching challenge](/ambition-institute/year-1-behaviour/autumn-week-12-ect-teaching-challenge)
-3. [Reflect](/ambition-institute/year-1-behaviour/autumn-week-12-ect-reflect)
+1. [Video](/ambition-institute/year-1-behaviour/autumn-week-12-ect-video 'Video week 12')
+2. [Teaching challenge](/ambition-institute/year-1-behaviour/autumn-week-12-ect-teaching-challenge 'Teaching challenge week 12')
+3. [Reflect](/ambition-institute/year-1-behaviour/autumn-week-12-ect-reflect 'Reflect week 12')
 
 ### Mentors
 
 Looks at how teachers can uphold high expectations by ensuring pupils are supported to achieve classroom success over time.
 
-[View mentor materials](/ambition-institute/year-1-behaviour/autumn-week-12-mentor-materials)
+[View mentor materials](/ambition-institute/year-1-behaviour/autumn-week-12-mentor-materials 'View mentor materials week 12')

--- a/content/teach-first/year-1-how-can-you-create-an-effective-learning-environment.md
+++ b/content/teach-first/year-1-how-can-you-create-an-effective-learning-environment.md
@@ -18,7 +18,7 @@ Duration: 10 minutes.
 
 Go through the module introduction to see what the ECT will be learning.
 
-[View mentor materials](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-1-mentor-materials)
+[View mentor materials](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-1-mentor-materials 'View mentors materials week 1')
 
 ## Week 2: establishing effective routines
 
@@ -29,9 +29,9 @@ During the first topic of the module you need to:
 
 Duration: 50 minutes.
 
-1. [Session Overview](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-2-ect-session-overview)
-2. [Theory](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-2-ect-theory)
-3. [Related Early Career Framework strands](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-2-ect-related-early-career-framework-strands)
+1. [Session Overview](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-2-ect-session-overview 'Session overview week 2')
+2. [Theory](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-2-ect-theory 'Theory week 2')
+3. [Related Early Career Framework strands](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-2-ect-related-early-career-framework-strands 'Related early career framework strands week 2')
 
 ### Mentors
 
@@ -40,7 +40,7 @@ Use the materials below to:
 - see what the ECT is learning
 - structure your catch-up with the ECT after watching them put this topic’s development focus into action in the classroom
 
-[View mentor materials](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-2-mentor-materials)
+[View mentor materials](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-2-mentor-materials 'View mentors materials week 2')
 
 ## Week 3: creating a positive and respectful classroom environment
 
@@ -51,9 +51,9 @@ For this topic you’ll need to:
 
 Duration: 30 minutes.
 
-1. [Session overview](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-3-ect-session-overview)
-2. [Theory](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-3-ect-theory)
-3. [Related Early Career Framework strands](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-3-ect-related-early-career-framework-strands)
+1. [Session overview](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-3-ect-session-overview 'Session overview week 3')
+2. [Theory](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-3-ect-theory 'Theory week 3')
+3. [Related Early Career Framework strands](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-3-ect-related-early-career-framework-strands 'Related early career framework strands week 3')
 
 ### Mentors
 
@@ -62,7 +62,7 @@ Use the materials below to:
 - see what the ECT is learning
 - structure your catch-up with the ECT after watching them put this topic’s development focus into action in the classroom
 
-[View mentor materials](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-3-mentor-materials)
+[View mentor materials](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-3-mentor-materials 'View mentors materials week 3')
 
 ## Week 4: addressing low-level behaviour
 
@@ -73,9 +73,9 @@ For this topic you’ll need to:
 
 Duration: 40 minutes.
 
-1. [Session overview](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-4-ect-session-overview)
-2. [Theory](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-4-ect-theory)
-3. [Related Early Career Framework strands](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-4-ect-related-early-career-framework-strands)
+1. [Session overview](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-4-ect-session-overview 'Session overview week 4')
+2. [Theory](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-4-ect-theory 'Theory week 4')
+3. [Related Early Career Framework strands](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-4-ect-related-early-career-framework-strands 'Related early career framework strands week 4')
 
 ### Mentors
 
@@ -84,7 +84,7 @@ Use the materials below to:
 - see what the ECT is learning
 - structure your catch-up with the ECT after watching them put this topic’s development focus into action in the classroom
 
-[View mentor materials](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-4-mentor-materials)
+[View mentor materials](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-4-mentor-materials 'View mentors materials week 4')
 
 ## Week 5: addressing persistent and challenging behaviour
 
@@ -95,15 +95,15 @@ For this topic you’ll need to:
 
 Duration: 50 minutes.
 
-1. [Session Overview](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-5-ect-session-overview)
-2. [Theory](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-5-ect-theory)
-3. [Related Early Career Framework strands](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-5-ect-related-early-career-framework-strands)
+1. [Session Overview](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-5-ect-session-overview 'Session overview week 5')
+2. [Theory](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-5-ect-theory 'Theory week 5')
+3. [Related Early Career Framework strands](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-5-ect-related-early-career-framework-strands 'Related early career framework strands week 5')
 
 ### Mentors
 
 Use the materials below to plan a discussion about this topic with the ECT during your catch-up.
 
-[View mentor materials](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-5-mentor-materials)
+[View mentor materials](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-5-mentor-materials 'View mentors materials week 5')
 
 ## Week 6: developing pupils’ intrinsic motivation
 
@@ -114,9 +114,9 @@ For this topic you’ll need to:
 
 Duration: 40 minutes.
 
-1. [Session Overview](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-6-ect-session-overview)
-2. [Theory](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-6-ect-theory)
-3. [Related Early Career Framework strands](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-6-ect-related-early-career-framework-strands)
+1. [Session Overview](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-6-ect-session-overview 'Session overview week 6')
+2. [Theory](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-6-ect-theory 'Theory week 6')
+3. [Related Early Career Framework strands](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-6-ect-related-early-career-framework-strands 'Related early career framework strands week 6')
 
 ### Mentors
 
@@ -125,7 +125,7 @@ Use the materials below to:
 - see what the ECT is learning
 - structure your catch-up with the ECT after watching them put this topic’s development focus into action in the classroom
 
-[View mentor materials](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-6-mentor-materials)
+[View mentor materials](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-6-mentor-materials 'View mentors materials week 6')
 
 ## Week 7: holding high expectations and maintaining engagement
 
@@ -136,9 +136,9 @@ For this topic you’ll need to:
 
 Duration: 50 minutes.
 
-1. [Session Overview](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-7-ect-session-overview)
-2. [Theory](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-7-ect-theory)
-3. [Related Early Career Framework strands](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-7-ect-related-early-career-framework-strands)
+1. [Session Overview](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-7-ect-session-overview 'Session overview week 7')
+2. [Theory](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-7-ect-theory 'Theory week 7')
+3. [Related Early Career Framework strands](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-7-ect-related-early-career-framework-strands 'Related early career framework strands week 7')
 
 ### Mentors
 
@@ -147,4 +147,4 @@ Use the materials below to:
 - see what the ECT is learning
 - structure your catch-up with the ECT after watching them put this topic’s development focus into action in the classroom
 
-[View mentor materials](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-7-mentor-materials)
+[View mentor materials](/teach-first/year-1-how-can-you-create-an-effective-learning-environment/autumn-week-7-mentor-materials 'View mentors materials week 7')

--- a/content/teach-first/year-1-how-do-pupils-learn.md
+++ b/content/teach-first/year-1-how-do-pupils-learn.md
@@ -27,15 +27,15 @@ During the first topic of the module you need to:
 
 Duration: 55 minutes.
 
-1. [Session overview](/teach-first/year-1-how-do-pupils-learn/autumn-week-1-ect-session-overview)
-2. [Theory](/teach-first/year-1-how-do-pupils-learn/autumn-week-1-ect-theory)
-3. [Related Early Career Framework strands](/teach-first/year-1-how-do-pupils-learn/autumn-week-1-ect-related-early-career-framework-strands)
+1. [Session overview](/teach-first/year-1-how-do-pupils-learn/autumn-week-1-ect-session-overview 'Session overview week 1')
+2. [Theory](/teach-first/year-1-how-do-pupils-learn/autumn-week-1-ect-theory 'Theory week 1')
+3. [Related Early Career Framework strands](/teach-first/year-1-how-do-pupils-learn/autumn-week-1-ect-related-early-career-framework-strands 'Related Early Career Framework strands week 1')
 
 ### Mentors
 
 Use the materials below to plan a discussion about this topic with the ECT during your catch-up.
 
-[View mentor materials](/teach-first/year-1-how-do-pupils-learn/autumn-week-1-mentor-materials)
+[View mentor materials](/teach-first/year-1-how-do-pupils-learn/autumn-week-1-mentor-materials 'View mentor materials week 1')
 
 ## Week 2: considering how to introduce new knowledge to pupils
 
@@ -46,9 +46,9 @@ For this topic you’ll need to:
 
 Duration: 60 minutes.
 
-1. [Session overview](/teach-first/year-1-how-do-pupils-learn/autumn-week-2-ect-session-overview)
-2. [Theory](/teach-first/year-1-how-do-pupils-learn/autumn-week-2-ect-theory)
-3. [Related Early Career Framework strands](/teach-first/year-1-how-do-pupils-learn/autumn-week-2-ect-related-early-career-framework-strands)
+1. [Session overview](/teach-first/year-1-how-do-pupils-learn/autumn-week-2-ect-session-overview 'Session overview week 2')
+2. [Theory](/teach-first/year-1-how-do-pupils-learn/autumn-week-2-ect-theory 'Theory week 2')
+3. [Related Early Career Framework strands](/teach-first/year-1-how-do-pupils-learn/autumn-week-2-ect-related-early-career-framework-strands 'Related Early Career Framework strands week 2')
 
 ### Mentors
 
@@ -57,7 +57,7 @@ Use the materials below to:
 - see what the ECT is learning
 - structure your catch-up with the ECT after watching them put this topic’s development focus into action in the classroom
 
-[View mentor materials](/teach-first/year-1-how-do-pupils-learn/autumn-week-2-mentor-materials)
+[View mentor materials](/teach-first/year-1-how-do-pupils-learn/autumn-week-2-mentor-materials 'View mentor materials week 2')
 
 ## Week 3: combining verbal explanation and graphical representations to reduce working memory overload
 
@@ -71,7 +71,7 @@ Use the materials below to:
 - see what the ECT is learning
 - structure your catch-up with the ECT after watching them put this topic’s development focus into action in the classroom
 
-[View mentor materials](/teach-first/year-1-how-do-pupils-learn/autumn-week-3-mentor-materials)
+[View mentor materials](/teach-first/year-1-how-do-pupils-learn/autumn-week-3-mentor-materials 'View mentor materials week 3')
 
 ## Week 4: using worked and partially completed examples
 
@@ -82,9 +82,9 @@ For this topic you’ll need to:
 
 Duration: 45 minutes.
 
-1. [Session overview](/teach-first/year-1-how-do-pupils-learn/autumn-week-4-ect-session-overview)
-2. [Theory](/teach-first/year-1-how-do-pupils-learn/autumn-week-4-ect-theory)
-3. [Related Early Career Framework strands](/teach-first/year-1-how-do-pupils-learn/autumn-week-4-ect-related-early-career-framework-strands)
+1. [Session overview](/teach-first/year-1-how-do-pupils-learn/autumn-week-4-ect-session-overview 'Session overview week 4')
+2. [Theory](/teach-first/year-1-how-do-pupils-learn/autumn-week-4-ect-theory 'Theory week 4')
+3. [Related Early Career Framework strands](/teach-first/year-1-how-do-pupils-learn/autumn-week-4-ect-related-early-career-framework-strands 'Related Early Career Framework strands week 4')
 
 ### Mentors
 
@@ -93,7 +93,7 @@ Use the materials below to:
 - see what the ECT is learning
 - structure your catch-up with the ECT after watching them put this topic’s development focus into action in the classroom
 
-[View mentor materials](/teach-first/year-1-how-do-pupils-learn/autumn-week-4-mentor-materials)
+[View mentor materials](/teach-first/year-1-how-do-pupils-learn/autumn-week-4-mentor-materials 'View mentor materials week 4')
 
 ## Week 5: helping pupils remember
 
@@ -104,15 +104,15 @@ For this topic you’ll need to:
 
 Duration: 80 minutes.
 
-1. [Session overview](/teach-first/year-1-how-do-pupils-learn/autumn-week-5-ect-session-overview)
-2. [Theory](/teach-first/year-1-how-do-pupils-learn/autumn-week-5-ect-theory)
-3. [Related Early Career Framework strands](/teach-first/year-1-how-do-pupils-learn/autumn-week-5-ect-related-early-career-framework-strands)
+1. [Session overview](/teach-first/year-1-how-do-pupils-learn/autumn-week-5-ect-session-overview 'Session overview week 5')
+2. [Theory](/teach-first/year-1-how-do-pupils-learn/autumn-week-5-ect-theory 'Theory week 5')
+3. [Related Early Career Framework strands](/teach-first/year-1-how-do-pupils-learn/autumn-week-5-ect-related-early-career-framework-strands 'Related Early Career Framework strands week 5')
 
 ### Mentors
 
 Use the materials below to plan a discussion about this topic with the ECT during your catch-up.
 
-[View mentor materials](/teach-first/year-1-how-do-pupils-learn/autumn-week-5-mentor-materials)
+[View mentor materials](/teach-first/year-1-how-do-pupils-learn/autumn-week-5-mentor-materials 'View mentor materials week 5')
 
 ## Week 6: practise using a low stakes quiz to strengthen pupils’ retrieval
 
@@ -123,7 +123,7 @@ There are no self-study materials this week. Instead, your mentor will lead the 
 
 Use the materials below to plan a discussion about this topic with the ECT during your catch-up.
 
-[View mentor materials](/teach-first/year-1-how-do-pupils-learn/autumn-week-6-mentor-materials)
+[View mentor materials](/teach-first/year-1-how-do-pupils-learn/autumn-week-6-mentor-materials 'View mentor materials week 6')
 
 ## Week 7: introduction to metacognition
 
@@ -134,12 +134,12 @@ For this topic you’ll need to:
 
 Duration: 15 minutes.
 
-1. [Session overview](/teach-first/year-1-how-do-pupils-learn/autumn-week-7-ect-session-overview)
-2. [Theory](/teach-first/year-1-how-do-pupils-learn/autumn-week-7-ect-theory)
-3. [Related Early Career Framework strands](/teach-first/year-1-how-do-pupils-learn/autumn-week-7-ect-related-early-career-framework-strands)
+1. [Session overview](/teach-first/year-1-how-do-pupils-learn/autumn-week-7-ect-session-overview 'Session overview week 7')
+2. [Theory](/teach-first/year-1-how-do-pupils-learn/autumn-week-7-ect-theory 'Theory week 7')
+3. [Related Early Career Framework strands](/teach-first/year-1-how-do-pupils-learn/autumn-week-7-ect-related-early-career-framework-strands 'Related Early Career Framework strands week 7')
 
 ### Mentors
 
 Use the materials below to plan a discussion about this topic with the ECT during your catch-up.
 
-[View mentor materials](/teach-first/year-1-how-do-pupils-learn/autumn-week-7-mentor-materials)
+[View mentor materials](/teach-first/year-1-how-do-pupils-learn/autumn-week-7-mentor-materials 'View mentor materials week 7')

--- a/content/ucl/year-1-enabling-pupil-learning.md
+++ b/content/ucl/year-1-enabling-pupil-learning.md
@@ -17,7 +17,7 @@ During your first week of a module, you and your mentor will take a look at the 
 
 During the first week of the module, you should take a look at the topics being covered. You should also catch up with the ECT to establish their level of confidence and agree areas to focus on.
 
-[View mentor materials](/ucl/year-1-enabling-pupil-learning/autumn-week-1-mentor-materials)
+[View mentor materials](/ucl/year-1-enabling-pupil-learning/autumn-week-1-mentor-materials 'View mentor materials week 1')
 
 ## Week 2: understanding teachers as role models
 
@@ -29,9 +29,9 @@ For this topic you’ll need to:
 Duration: 45 minutes.
 
 1. [Module introduction](/ucl/year-1-enabling-pupil-learning/autumn-week-2-ect-module-introduction)
-2. [What you’ll learn this week](/ucl/year-1-enabling-pupil-learning/autumn-week-2-ect-what-you'll-learn-this-week)
-3. [Research and practice summary](/ucl/year-1-enabling-pupil-learning/autumn-week-2-ect-research-and-practice-summary)
-4. [Self-study activities](/ucl/year-1-enabling-pupil-learning/autumn-week-2-ect-self-study-activities)
+2. [What you’ll learn this week](/ucl/year-1-enabling-pupil-learning/autumn-week-2-ect-what-you'll-learn-this-week 'What you’ll learn this week 2')
+3. [Research and practice summary](/ucl/year-1-enabling-pupil-learning/autumn-week-2-ect-research-and-practice-summary 'Research and practice summary week 2')
+4. [Self-study activities](/ucl/year-1-enabling-pupil-learning/autumn-week-2-ect-self-study-activities 'Self-study activities week 2')
 
 ### Mentors
 
@@ -40,7 +40,7 @@ Use the materials below to:
 - see what the ECT is learning
 - structure your catch-up with the ECT
 
-[View mentor materials](/ucl/year-1-enabling-pupil-learning/autumn-week-2-mentor-materials)
+[View mentor materials](/ucl/year-1-enabling-pupil-learning/autumn-week-2-mentor-materials 'View mentor materials week 2')
 
 ## Week 3: establishing the learning environment
 
@@ -51,9 +51,9 @@ For this topic you’ll need to:
 
 Duration: 45 minutes.
 
-1. [What you’ll learn in this topic](/ucl/year-1-enabling-pupil-learning/autumn-week-3-ect-what-you'll-learn-in-this-topic)
-2. [Research and practice summary](/ucl/year-1-enabling-pupil-learning/autumn-week-3-ect-research-and-practice-summary)
-3. [Self-study activities](/ucl/year-1-enabling-pupil-learning/autumn-week-3-ect-self-study-activities)
+1. [What you’ll learn in this topic](/ucl/year-1-enabling-pupil-learning/autumn-week-3-ect-what-you'll-learn-in-this-topic 'What you’ll learn this week 3')
+2. [Research and practice summary](/ucl/year-1-enabling-pupil-learning/autumn-week-3-ect-research-and-practice-summary 'Research and practice summary week 3')
+3. [Self-study activities](/ucl/year-1-enabling-pupil-learning/autumn-week-3-ect-self-study-activities 'Self-study activities week 3')
 
 ### Mentors
 
@@ -62,7 +62,7 @@ Use the materials below to:
 - see what the ECT is learning
 - structure your catch-up with the ECT
 
-[View mentor materials](/ucl/year-1-enabling-pupil-learning/autumn-week-3-mentor-materials)
+[View mentor materials](/ucl/year-1-enabling-pupil-learning/autumn-week-3-mentor-materials 'View mentor materials week 3')
 
 ## Week 4: supporting the most vulnerable pupils
 
@@ -73,7 +73,7 @@ You don’t have any self-study materials this week, but there will be a meeting
 
 The ECT does not have a self-study element this week. Instead, you should use the materials below to help you plan a discussion with them about this topic.
 
-[View mentor materials](/ucl/year-1-enabling-pupil-learning/autumn-week-4-mentor-materials)
+[View mentor materials](/ucl/year-1-enabling-pupil-learning/autumn-week-4-mentor-materials 'View mentor materials week 4')
 
 ## Week 5: understanding pupils as learners
 
@@ -84,9 +84,9 @@ For this topic you’ll need to:
 
 Duration: 45 minutes.
 
-1. [Learning Intentions and Introduction](/ucl/year-1-enabling-pupil-learning/autumn-week-5-ect-learning-intentions-and-introduction)
-2. [Research and Practice Summary](/ucl/year-1-enabling-pupil-learning/autumn-week-5-ect-research-and-practice-summary)
-3. [Self-Study Activities](/ucl/year-1-enabling-pupil-learning/autumn-week-5-ect-self-study-activities)
+1. [Learning Intentions and Introduction](/ucl/year-1-enabling-pupil-learning/autumn-week-5-ect-learning-intentions-and-introduction 'Learning Intentions and Introduction week 5')
+2. [Research and Practice Summary](/ucl/year-1-enabling-pupil-learning/autumn-week-5-ect-research-and-practice-summary 'Research and practice summary week 5')
+3. [Self-Study Activities](/ucl/year-1-enabling-pupil-learning/autumn-week-5-ect-self-study-activities 'Self-study activities week 5')
 
 ### Mentors
 
@@ -95,7 +95,7 @@ Use the materials below to:
 - see what the ECT is learning
 - structure your catch-up with the ECT
 
-[View mentor materials](/ucl/year-1-enabling-pupil-learning/autumn-week-5-mentor-materials)
+[View mentor materials](/ucl/year-1-enabling-pupil-learning/autumn-week-5-mentor-materials 'View mentor materials week 5')
 
 ## Week 6: managing behaviour
 
@@ -106,9 +106,9 @@ For this topic you’ll need to:
 
 Duration: 45 minutes.
 
-1. [Learning Intentions and Introduction](/ucl/year-1-enabling-pupil-learning/autumn-week-6-ect-learning-intentions-and-introduction)
-2. [Research and Practice Summary](/ucl/year-1-enabling-pupil-learning/autumn-week-6-ect-research-and-practice-summary)
-3. [Self-Study Activities](/ucl/year-1-enabling-pupil-learning/autumn-week-6-ect-self-study-activities)
+1. [Learning Intentions and Introduction](/ucl/year-1-enabling-pupil-learning/autumn-week-6-ect-learning-intentions-and-introduction 'Learning Intentions and Introduction week 6')
+2. [Research and Practice Summary](/ucl/year-1-enabling-pupil-learning/autumn-week-6-ect-research-and-practice-summary 'Research and practice summary week 6')
+3. [Self-Study Activities](/ucl/year-1-enabling-pupil-learning/autumn-week-6-ect-self-study-activities 'Self-study activities week 6')
 
 ### Mentors
 
@@ -117,7 +117,7 @@ Use the materials below to:
 - see what the ECT is learning
 - structure your catch-up with the ECT
 
-[View mentor materials](/ucl/year-1-enabling-pupil-learning/autumn-week-6-mentor-materials)
+[View mentor materials](/ucl/year-1-enabling-pupil-learning/autumn-week-6-mentor-materials 'View mentor materials week 6')
 
 ## Week 7: exploring yourself as a role model
 
@@ -133,4 +133,4 @@ Use the materials below to:
 - see what the ECT is learning
 - structure your catch-up with the ECT
 
-[View mentor materials](/ucl/year-1-enabling-pupil-learning/autumn-week-7-mentor-materials)
+[View mentor materials](/ucl/year-1-enabling-pupil-learning/autumn-week-7-mentor-materials 'View mentor materials week 7')

--- a/content/ucl/year-2-inquiry-into-developing-quality-pedagogy-and-making-productive-use-of-assessment-part-3.md
+++ b/content/ucl/year-2-inquiry-into-developing-quality-pedagogy-and-making-productive-use-of-assessment-part-3.md
@@ -15,7 +15,7 @@ There are no self-study materials this week. Instead, you will meet your mentor 
 
 Use the materials below to consider emergent evidence regarding the ECT’s practitioner inquiry.
 
-[View mentor materials](/ucl/year-2-inquiry-into-developing-quality-pedagogy-and-making-productive-use-of-assessment-part-3/summer-week-1-mentor-materials)
+[View mentor materials](/ucl/year-2-inquiry-into-developing-quality-pedagogy-and-making-productive-use-of-assessment-part-3/summer-week-1-mentor-materials 'View mentor materials week 1')
 
 ## Week 2: the impact your enquiry has had on you
 
@@ -40,7 +40,7 @@ There are no self-study materials this week. Instead, you will meet your mentor 
 
 Use the materials below as a platform to discuss the impact their inquiry has had on them.
 
-[View mentor materials](/ucl/year-2-inquiry-into-developing-quality-pedagogy-and-making-productive-use-of-assessment-part-3/summer-week-3-mentor-materials)
+[View mentor materials](/ucl/year-2-inquiry-into-developing-quality-pedagogy-and-making-productive-use-of-assessment-part-3/summer-week-3-mentor-materials 'View mentor materials week 3')
 
 ## Week 4
 
@@ -60,4 +60,4 @@ There are no self-study materials this week. Instead, you will meet your mentor 
 
 This week the ECT should meet you to present their findings from this moudle’s practitioner inquiry.
 
-[View mentor materials](/ucl/year-2-inquiry-into-developing-quality-pedagogy-and-making-productive-use-of-assessment-part-3/summer-week-5-mentor-materials)
+[View mentor materials](/ucl/year-2-inquiry-into-developing-quality-pedagogy-and-making-productive-use-of-assessment-part-3/summer-week-5-mentor-materials 'View mentor materials week 5')


### PR DESCRIPTION
A few links on the pages changed in this PR contain links with the same text but pointing to different URLs.
This condition raises an accessibility issue that is fixed by setting the links' titles.

For example, links like:
`[View mentor materials](/ambition-institute/year-1-behaviour/autumn-week-1-mentor-materials)`
have been changed to
`[View mentor materials](/ambition-institute/year-1-behaviour/autumn-week-1-mentor-materials 'View mentor materials week 1')`
since there are many `View mentor materials` links on the same page, each pointing to a specific week number.

The markdown syntax above sets the `title` property on the `a` HTML tag.